### PR TITLE
Improve introduction about disassembling and document `asm.cpu`

### DIFF
--- a/src/configuration/evars.md
+++ b/src/configuration/evars.md
@@ -13,6 +13,10 @@ The Visual mode has an eval browser that is accessible through the `Vbe` command
 Defines the target CPU architecture used for disassembling (`pd`, `pD` commands) and code analysis (`a` command). You can find the list of possible values by looking at the result of `e asm.arch=?` or `rz-asm -L`.
 It is quite simple to add new architectures for disassembling and analyzing code. There is an interface for that. For x86, it is used to attach a number of third-party disassembler engines, including GNU binutils, Udis86 and a few handmade ones.
 
+### asm.cpu
+
+You can use this configuration variable to define the CPU type. For example, if you had picked the architecture as AVR, you can choose your CPU type (ATmega1281, ATmega2561, etc) using `asm.cpu`.
+
 ### asm.bits
 
 Determines width in bits of registers for the current architecture. Supported values: 8, 16, 32, 64. Note that not all target architectures support all combinations for asm.bits.

--- a/src/disassembling/intro.md
+++ b/src/disassembling/intro.md
@@ -30,8 +30,21 @@ To see the disassembly, use the `pd` command. It accepts a numeric argument to s
 [0x00000000]> pd 3     ; disassemble 3 opcodes
 [0x00000000]> pD 30    ; disassemble 30 bytes
 ```
+You can also pass negative numbers as the numeric argument, if you want to disassemble something that lies before the current offset:
+
+```
+[0x00005bc0]> pd -2
+            0x00005bb8      ret
+            0x00005bb9      nop dword [rax]
+[0x00005bc0]> pd 2
+            ;-- entry.fini0:
+            0x00005bc0      endbr64
+            0x00005bc4      cmp byte [0x000232c8], 0
+```
 
 The `pD` command works like `pd` but accepts the number of input bytes as its argument, instead of the number of opcodes.
+
+You can also dissassemble get information about the pointer chains using the command `pdp`. This can be helpful while dealing with ROP chains.
 
 The "pseudo" syntax may be somewhat easier for a human to understand than the default assembler notations. But it can become annoying if you read lots of code. To play with it:
 
@@ -58,3 +71,4 @@ The "pseudo" syntax may be somewhat easier for a human to understand than the de
 		  0x00405e2d    4889d8       mov %rbx, %rax
 ```
 
+And as always, you can print the disassembly in JSON using `pdj` and get more information about the other associated commands by running `pd?`.

--- a/src/disassembling/intro.md
+++ b/src/disassembling/intro.md
@@ -44,7 +44,7 @@ You can also pass negative numbers as the numeric argument, if you want to disas
 
 The `pD` command works like `pd` but accepts the number of input bytes as its argument, instead of the number of opcodes.
 
-You can also dissassemble get information about the pointer chains using the command `pdp`. This can be helpful while dealing with ROP chains.
+You can also get information about the pointer chains using the command `pdp`. This can be helpful while dealing with ROP chains.
 
 The "pseudo" syntax may be somewhat easier for a human to understand than the default assembler notations. But it can become annoying if you read lots of code. To play with it:
 

--- a/src/first_steps/getting_rizin.md
+++ b/src/first_steps/getting_rizin.md
@@ -1,6 +1,6 @@
 ## Downloading rizin
 
-You can get rizin from the website, [http://rizin.org](http://rizin.org),
+You can get rizin from the website, [http://rizin.re](http://rizin.re),
 or the GitHub repository: [https://github.com/rizinorg/rizin](https://github.com/rizinorg/rizin)
 
 Binary packages will soon be available for most common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.

--- a/src/first_steps/getting_rizin.md
+++ b/src/first_steps/getting_rizin.md
@@ -1,8 +1,5 @@
 ## Downloading rizin
 
-You can get rizin from the website, [http://rizin.re](http://rizin.re),
-or the GitHub repository: [https://github.com/rizinorg/rizin](https://github.com/rizinorg/rizin)
-
 Binary packages will soon be available for most common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
 
 Please have a look at file [BUILDING.md](https://github.com/rizinorg/rizin/blob/dev/BUILDING.md) in Rizin repository for more detailed instructions on how to build the tool.


### PR DESCRIPTION
* Added a short explanation about `asm.cpu`.
* Improve documentation about introduction on disassembling: added documented `pdp` and `pdj`command.
* Fixed the link at the chapter Getting Started. The link originally pointed to `rizin.org`.