### PR TITLE
Add an example about using rz-pipe with Ruby

### DIFF
--- a/src/scripting/rz-pipe.md
+++ b/src/scripting/rz-pipe.md
@@ -75,3 +75,18 @@ Rust
      rzp.close();
  }
 ```
+
+Ruby
+-----
+```ruby
+require './rzpipe'
+
+begin
+  rzp = RzPipe.new
+rescue Exception => e
+  rzp = RzPipe.new '/bin/ls'
+end
+  puts rzp.cmd 'a'
+  puts rzp.cmd 'pd 10 main'
+  rzp.quit
+```


### PR DESCRIPTION
Since Ruby's support was added, this commit adds an example about using rz-pipe with Ruby.
See https://github.com/rizinorg/rz-pipe/pull/6