### PR TITLE
Fix minor calculation in ioli_0x02

### DIFF
--- a/src/crackmes/ioli/ioli_0x02.md
+++ b/src/crackmes/ioli/ioli_0x02.md
@@ -92,7 +92,7 @@ for example:
 |           0x080483fe      29c4           sub esp, eax
 ```
 
-we can easily get the value of eax. it's 0x16.
+we can easily get the value of eax. it's 16.
 
 It gets hard when the scale of program grows. rizin provides a pseudo disassembler output in C-like syntax. It may be useful.
 ```


### PR DESCRIPTION
0x16 was used instead of 16 (or 0x10).