### PR TITLE
CI: update mdbook to 0.4.7

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.7'
+          mdbook-version: "0.4.7"
           # mdbook-version: 'latest'
 
       - run: mdbook build

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   deploy:
@@ -20,6 +23,7 @@ jobs:
       - run: mdbook build
 
       - name: Deploy
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:
- updates mdBook version in CI to 0.4.7
- enables build on PRs too.

I just wanted [this commit](https://github.com/rust-lang/mdBook/pull/1188), but it works fine on the latest version as well.
