### PR TITLE
Fix spelling mistakes globally using Codespell

### DIFF
--- a/src/analysis/code_analysis.md
+++ b/src/analysis/code_analysis.md
@@ -4,7 +4,7 @@ Code analysis is a common technique used to extract information from assembly co
 
 Rizin has different code analysis techniques implemented in the core and available in different commands.
 
-As long as the whole functionalities of rizin are available with the API as well as using commands. This gives you the ability to implement your own analysis loops using any programming language, even with rizin oneliners, shellscripts, or analysis or core native plugins.
+As long as the whole functionalities of rizin are available with the API as well as using commands. This gives you the ability to implement your own analysis loops using any programming language, even with rizin one-liners, shellscripts, or analysis or core native plugins.
 
 The analysis will show up the internal data structures to identify basic blocks, function trees and to extract opcode-level information.
 

--- a/src/basic_commands/write.md
+++ b/src/basic_commands/write.md
@@ -68,7 +68,7 @@ an operator. The command is applied to the current block. Supported operators in
 |Supported operations:
 |  wow  ==  write looped value (alias for 'wb')
 |  woa  +=  addition
-|  wos  -=  substraction
+|  wos  -=  subtraction
 |  wom  *=  multiply
 |  wod  /=  divide
 |  wox  ^=  xor

--- a/src/configuration/evars.md
+++ b/src/configuration/evars.md
@@ -17,7 +17,7 @@ The `el` command to get help on all the evaluable configuration variables of riz
       scr.color.pipe: Enable colors when using pipes
      scr.prompt.mode: Set prompt color based on vi mode
          scr.rainbow: Shows rainbow colors depending of address
-         scr.randpal: Random color palete or just get the next one from 'eco'
+         scr.randpal: Random color palette or just get the next one from 'eco'
 ```
 
 The Visual mode has an eval browser that is accessible through the `Vbe` command.
@@ -107,7 +107,7 @@ Selects a target operating system for the currently loaded binary. Usually, OS i
 
 ### asm.pseudo: `bool`
 
-A boolean value to set the psuedo syntax in the disassembly. "False" indicates a native one, defined by the current architecture, "true" activates a pseudocode strings format. For example, it'll transform :
+A boolean value to set the pseudo syntax in the disassembly. "False" indicates a native one, defined by the current architecture, "true" activates a pseudocode strings format. For example, it'll transform :
 
 ```
 │           0x080483ff      e832000000     call 0x8048436
@@ -264,7 +264,7 @@ A boolean value that controls displaying of tracing information (sequence number
 
 ### dbg.follow.child: `bool`
 
-This variable lets you follow the child procoess, when a fork (system call) is encountered during debugging. By default, it is set to `false` and the parent process is traced.
+This variable lets you follow the child process, when a fork (system call) is encountered during debugging. By default, it is set to `false` and the parent process is traced.
 
 ## Screen Configuration
 
@@ -359,7 +359,7 @@ This variable lets you set the size of stack in bytes.
 
 ## cmd.repeat: `bool`
 
-Sometimes, you may need to run the same commmand repeatedly and that is what `cmd.repeat` is for. When set to `true`, pressing Return key (Enter key) will run the previous command again.
+Sometimes, you may need to run the same command repeatedly and that is what `cmd.repeat` is for. When set to `true`, pressing Return key (Enter key) will run the previous command again.
 
 For example:
 ```

--- a/src/configuration/files.md
+++ b/src/configuration/files.md
@@ -37,5 +37,5 @@ Each user in the system can have its own rizin scripts to run on startup to sele
 
 ### Target file
 
-If you want to run a script everytime you open a file, just create a file with the same name of the file
+If you want to run a script every time you open a file, just create a file with the same name of the file
 but appending `.rz` to it.

--- a/src/crackmes/avatao/01-reverse4/first_steps.md
+++ b/src/crackmes/avatao/01-reverse4/first_steps.md
@@ -118,7 +118,7 @@ d 0x400db4 mov edi, str.You_won__The_flag_is:__s_n
 d 0x400dd2 mov edi, str.Your_getting_closer_
 ```
 
-> ***rizin tip***: We can list crossreferences to addresses using the *axt [addr]*
+> ***rizin tip***: We can list cross-references to addresses using the *axt [addr]*
 > command (similarly, we can use *axf* to list references from the address).
 > The *@@* is an iterator, it just runs the command once for every arguments
 > listed.

--- a/src/crackmes/avatao/01-reverse4/vmloop.md
+++ b/src/crackmes/avatao/01-reverse4/vmloop.md
@@ -146,7 +146,7 @@ of *vmloop*.
 
 As I've mentioned previously, the function itself is pretty short, and easy to
 read, especially with our annotations. But a promise is a promise, so here is
-how we can create the missing bacic blocks for the instructions:
+how we can create the missing basic blocks for the instructions:
 
 ```
 [0x00400ec0]> afb+ 0x00400a45 0x00400a80 0x00400ab6-0x00400a80 0x400c15

--- a/src/disassembling/adding_metadata.md
+++ b/src/disassembling/adding_metadata.md
@@ -83,7 +83,7 @@ The `Cf` command is used to define a memory format string (the same syntax used 
 
 The `[sz]` argument to `Cf` is used to define how many bytes the struct should take up in the disassembly, and is completely independent from the size of the data structure defined by the format string. This may seem confusing, but has several uses. For example, you may want to see the formatted structure displayed in the disassembly, but still have those locations be visible as offsets and with raw bytes. Sometimes, you find large structures, but only identified a few fields, or only interested in specific fields. Then, you can tell rizin to display only those fields, using the format string and using 'skip' fields, and also have the disassembly continue after the entire structure, by giving it full size using the `sz` argument.
 
-Using `Cf`, it's easy to define complex structures with simple oneliners. See `pf?` for more information.
+Using `Cf`, it's easy to define complex structures with simple one-liners. See `pf?` for more information.
 Remember that all these `C` commands can also be accessed from the visual mode by pressing the `d` (data conversion) key.
 Note that unlike [`t`](../analysis/types.md) commands `Cf` doesn't change analysis results. It is only
 a visual boon.

--- a/src/disassembling/esil.md
+++ b/src/disassembling/esil.md
@@ -270,9 +270,9 @@ Properties of the VM variables:
 
 ### Bit Arrays
 
-What to do with them? What about bit arithmetics if use variables instead of registers?
+What to do with them? What about bit arithmetic if use variables instead of registers?
 
-### Arithmetics
+### Arithmetic
 
 1. ADD ("+")
 2. MUL ("\*")
@@ -281,7 +281,7 @@ What to do with them? What about bit arithmetics if use variables instead of reg
 5. MOD ("%")
 
 
-### Bit Arithmetics
+### Bit Arithmetic
 
 1. AND  "&"
 2. OR   "|"

--- a/src/first_steps/basic_debugger_session.md
+++ b/src/first_steps/basic_debugger_session.md
@@ -11,7 +11,7 @@ $ rizin -a arm -b 16 -d gdb://192.168.1.43:9090
 ...
 ```
 
-In the second case, the debugger will fork and load the debugee `ls` program in memory.
+In the second case, the debugger will fork and load the debuggee `ls` program in memory.
 
 It will pause its execution early in `ld.so` dynamic linker. As a result, you will not yet see the entrypoint or any shared libraries at this point.
 

--- a/src/plugins/intro.md
+++ b/src/plugins/intro.md
@@ -41,7 +41,7 @@ Those are some of the commands:
 L          # list core plugins
 iL         # list bin plugins
 dL         # list debug plugins
-ph         # print support hash algoriths
+ph         # print support hash algorithms
 ```
 
 You can use the `?` as value to get the possible values in the associated eval vars.

--- a/src/scripting/macros.md
+++ b/src/scripting/macros.md
@@ -31,7 +31,7 @@ family: cpu
 [0x00404800]>
 ```
 
-To list available macroses simply call `(*`:
+To list available macros simply call `(*`:
 ```
 [0x00404800]> (*
 (qwe ; pd 4; ao)

--- a/src/search_bytes/searching_aes_keys.md
+++ b/src/search_bytes/searching_aes_keys.md
@@ -24,7 +24,7 @@ hits: 0
 010 0x000096d4 0x000196d4 GLOBAL    OBJ   16 AES_KEY
 ```
 
-Other than that, AES keys might show up in different ways in the binary: encrypted, hidden by another encrypting routine, so there's no absolute way other than understanding the binary being analized. For instance, `p=e` might give some hints if high(er) entropy sections are found trying to cover up a hardcoded secret. As an example on entropy searching, since rizin 3.2.0, there's the possibility to delimit entropy sections for later use like so:
+Other than that, AES keys might show up in different ways in the binary: encrypted, hidden by another encrypting routine, so there's no absolute way other than understanding the binary being analyzed. For instance, `p=e` might give some hints if high(er) entropy sections are found trying to cover up a hardcoded secret. As an example on entropy searching, since rizin 3.2.0, there's the possibility to delimit entropy sections for later use like so:
 
 ```
 [0x00000000]> b

--- a/src/signatures/zignatures.md
+++ b/src/signatures/zignatures.md
@@ -87,7 +87,7 @@ hits: 1
 ```
 Note that `z.` command just checks the signatures against the current address.
 To search signatures across the all file we need to do a bit different thing.
-There is an important moment though, if we just run it "as is" - it wont find anything:
+There is an important moment though, if we just run it "as is" - it won't find anything:
 ```
 [0x000051c0]> z/
 [+] searching 0x0021dfd0 - 0x002203e8

--- a/src/visual_mode/intro.md
+++ b/src/visual_mode/intro.md
@@ -32,7 +32,7 @@ Visual mode help:
  ??       show the user-friendly hud
  %        in cursor mode finds matching pair, or toggle autoblocksz
  @        redraw screen every 1s (multi-user view)
- ^        seek to the begining of the function
+ ^        seek to the beginning of the function
  !        enter into the visual panels mode
  _        enter the flag/comment/functions/.. hud (same as VF_)
  =        set cmd.vprompt (top row)

--- a/src/visual_mode/visual_disassembly.md
+++ b/src/visual_mode/visual_disassembly.md
@@ -47,7 +47,7 @@ Pressing lowercase `c` toggles the cursor mode. When this mode is active, the cu
 
 ![Cursor at 0x00404896](cursor.png)
 
-The cursor is used to select a range of bytes or simply to point to a byte. You can use the cursor to create a named flag at specifc location. To do so, seek to the required position, then press `f` and enter a name for a flag.
+The cursor is used to select a range of bytes or simply to point to a byte. You can use the cursor to create a named flag at specific location. To do so, seek to the required position, then press `f` and enter a name for a flag.
 If the file was opened in write mode using the `-w` flag or the `o+` command, you can also use the cursor to overwrite a selected range with new values. To do so, select a range of bytes (with HJKL and SHIFT key pressed), then press `i` and enter the hexpair values for the new data. The data will be repeated as needed to fill the range selected. For example:
 ```
 <select 10 bytes in visual mode using SHIFT+HJKL>


### PR DESCRIPTION
Codespell is a tool for fix spelling mistakes in the source code.

Link: https://github.com/codespell-project/codespell/

I ran
`$ codespell -w --skip *.png --ignore-words-list Gameboy,GameBoy,te,fo,ND,ptd -i 1`
and applied the changes interactively.