### PR TITLE
Remove outdated links and add the link to the Rizin blog

### DIFF
--- a/src/crackmes/avatao/01-reverse4/rizin.md
+++ b/src/crackmes/avatao/01-reverse4/rizin.md
@@ -71,5 +71,5 @@ use the git version!
 
 Some highly recommended reading materials:
 
-- [Rizin Book](https://www.gitbook.com/book/rizinorg/rizinbook/details)
+- [Rizin Book](https://book.rizin.re)
 - [Rizin Blog](https://rizin.re/posts/)

--- a/src/crackmes/avatao/01-reverse4/rizin.md
+++ b/src/crackmes/avatao/01-reverse4/rizin.md
@@ -71,7 +71,5 @@ use the git version!
 
 Some highly recommended reading materials:
 
-- [Cheatsheet by pwntester](https://github.com/pwntester/cheatsheets/blob/master/rizin.md)
 - [Rizin Book](https://www.gitbook.com/book/rizinorg/rizinbook/details)
-- [Rizin Blog](http://rizin.today)
-- [Rizin Wiki](https://github.com/rizinorg/rizin/wiki)
+- [Rizin Blog](https://rizin.re/posts/)


### PR DESCRIPTION
1. removed cheatsheet by pwntester.
2. removed rizin wike which isn't actually present 
3. changed `https://rizin.today` to `https://rizin.re/posts/`