### PR TITLE
Removed link to developers page & updated link to binary packages

### DIFF
--- a/src/first_steps/contributing.md
+++ b/src/first_steps/contributing.md
@@ -14,5 +14,5 @@ Suggested contributions include:
 
 Please get permission to port any content you do not own/did not create before you put it in the Rizin book.
 
-See <https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md> for general help on contributing to rizin.
+See <https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md> for general help on contributing to rizin.
 

--- a/src/first_steps/getting_rizin.md
+++ b/src/first_steps/getting_rizin.md
@@ -1,5 +1,6 @@
 ## Downloading rizin
 
-Binary packages will soon be available for most common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
+Binary packages are available for most common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
 
+Please have a look at [releases](https://github.com/rizinorg/rizin/releases) in rizin repository for binary packages
 Please have a look at file [BUILDING.md](https://github.com/rizinorg/rizin/blob/dev/BUILDING.md) in Rizin repository for more detailed instructions on how to build the tool.

--- a/src/first_steps/getting_rizin.md
+++ b/src/first_steps/getting_rizin.md
@@ -1,6 +1,6 @@
 ## Downloading rizin
 
-Binary packages are available for most of common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
+Binary packages are available for most of the common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
 
 Please have a look at [releases](https://github.com/rizinorg/rizin/releases) in rizin repository for binary packages
 Please have a look at file [BUILDING.md](https://github.com/rizinorg/rizin/blob/dev/BUILDING.md) in Rizin repository for more detailed instructions on how to build the tool.

--- a/src/first_steps/getting_rizin.md
+++ b/src/first_steps/getting_rizin.md
@@ -2,5 +2,5 @@
 
 Binary packages are available for most of the common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
 
-Please have a look at [releases](https://github.com/rizinorg/rizin/releases) in rizin repository for binary packages
-Please have a look at file [BUILDING.md](https://github.com/rizinorg/rizin/blob/dev/BUILDING.md) in Rizin repository for more detailed instructions on how to build the tool.
+Please have a look at the [releases](https://github.com/rizinorg/rizin/releases) tab of Rizin's GitHub repository for the binary packages.
+See [BUILDING.md](https://github.com/rizinorg/rizin/blob/dev/BUILDING.md) for more detailed instructions on how to build the tool.

--- a/src/first_steps/getting_rizin.md
+++ b/src/first_steps/getting_rizin.md
@@ -1,6 +1,6 @@
 ## Downloading rizin
 
-Binary packages are available for most common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
+Binary packages are available for most of common platforms (e.g. Windows, MacOS, Linux), however you can still compile rizin yourself for many other architectures/operating systems.
 
 Please have a look at [releases](https://github.com/rizinorg/rizin/releases) in rizin repository for binary packages
 Please have a look at file [BUILDING.md](https://github.com/rizinorg/rizin/blob/dev/BUILDING.md) in Rizin repository for more detailed instructions on how to build the tool.


### PR DESCRIPTION
changed `https://github.com/rizinorg/rizin/blob/master/DEVELOPERS.md` to `https://github.com/rizinorg/rizin/blob/dev/CONTRIBUTING.md`