### PR TITLE
typo in python rz-pipe package

### DIFF
--- a/src/scripting/rz-pipe.md
+++ b/src/scripting/rz-pipe.md
@@ -27,7 +27,7 @@ $ pip install rzpipe
 ```python
 import rzpipe
 
-rz = rz-pipe.open("/bin/ls")
+rz = rzpipe.open("/bin/ls")
 rz.cmd('aa')
 print(rz.cmd("afl"))
 print(rz.cmdj("aflj"))  # evaluates JSONs and returns an object

--- a/src/scripting/rz-pipe.md
+++ b/src/scripting/rz-pipe.md
@@ -21,7 +21,7 @@ Python
 ------
 
 ```
-$ pip install rz-pipe
+$ pip install rzpipe
 ```
 
 ```python


### PR DESCRIPTION
hi! it's just a small typo in the `pip install rz-pipe` command