### PR TITLE
Replace old `?` command with new `%` (#99)

### DIFF
--- a/src/basic_commands/sdb.md
+++ b/src/basic_commands/sdb.md
@@ -94,13 +94,13 @@ fd.6
 [0x08048320]> k bin/fd.6/*
 archs=0:0:x86:32
 ```
-The file corresponding to the sixth file descriptor is a x86_32 binary.
+The file corresponding to the sixth file descriptor is a x86\_32 binary.
 
 ```
 [0x08048320]> k analysis/meta/*
 meta.s.0x80484d0=12,SGVsbG8gd29ybGQ=
 [...]
-[0x08048320]> ?b64- SGVsbG8gd29ybGQ=
+[0x08048320]> %b64- SGVsbG8gd29ybGQ=
 Hello world
 ```
 Strings are stored encoded in base64.

--- a/src/crackmes/avatao/01-reverse4/main.md
+++ b/src/crackmes/avatao/01-reverse4/main.md
@@ -54,11 +54,22 @@ We can see that the program reads a word (2 bytes) into the local variable named
 *local_10_6*, and than compares it to 0xbb8. That's 3000 in decimal:
 
 ```
-[0x00400c63]> ? 0xbb8
-3000 0xbb8 05670 2.9K 0000:0bb8 3000 10111000 3000.0 0.000000f 0.000000
+[0x00400c63]> % 0xbb8
+int32   3000
+uint32  3000
+hex     0xbb8
+octal   05670
+unit    2.9K
+segment 0000:0bb8
+string  "\xb8\v"
+fvalue  3000.0
+float   3000.000000f
+double  3000.000000
+binary  0b0000101110111000
+trits   0t11010010
 ```
 
-> ***rizin tip***: yep, *?* will evaluate expressions, and print the result in
+> ***rizin tip***: yep, *%* will evaluate expressions, and print the result in
 > various formats.
 
 If the value is greater than 3000, then it will be forced to be 3000:

--- a/src/crackmes/avatao/01-reverse4/vmloop.md
+++ b/src/crackmes/avatao/01-reverse4/vmloop.md
@@ -59,14 +59,14 @@ series of qwords:
 
 ```
 [0x00400a74]> s 0x00400ec0
-[0x00400ec0]> Cd 8 @@=`?s $$ $$+8*0x17 8`
+[0x00400ec0]> Cd 8 @@=`%s $$ $$+8*0x17 8`
 ```
 
-> ***rizin tip***: Except for the *?s*, all parts of this command should be
+> ***rizin tip***: Except for the *%s*, all parts of this command should be
 > familiar now, but lets recap it! *Cd* defines a memory area as data, and 8 is
 > the size of that memory area. *@@* is an iterator that make the preceding
 > command run for every element that *@@* holds. In this example it holds a
-> series generated using the *?s* command. *?s* simply generates a series from
+> series generated using the *%s* command. *%s* simply generates a series from
 > the current seek (*$$*) to current seek + 8*0x17 (*$$+8*0x17*) with a step
 > of 8.
 

--- a/src/crackmes/ioli/ioli_0x01.md
+++ b/src/crackmes/ioli/ioli_0x01.md
@@ -87,10 +87,10 @@ If you look carefully, you'll see a `cmp` instruction, with a constant, 0x149a. 
 0x0804842b    817dfc9a140. cmp dword [ebp + 0xfffffffc], 0x149a
 ```
 
-You can use rizin's `?` command to display 0x149a in another numeric base.
+You can use rizin's `%` command to display 0x149a in another numeric base.
 
 ```
-[0x08048330]> ? 0x149a
+[0x08048330]> % 0x149a
 int32   5274
 uint32  5274
 hex     0x149a
@@ -98,9 +98,9 @@ octal   012232
 unit    5.2K
 segment 0000:049a
 string  "\x9a\x14"
-fvalue: 5274.0
-float:  0.000000f
-double: 0.000000
+fvalue  5274.0
+float   5274.000000f
+double  5274.000000
 binary  0b0001010010011010
 trits   0t21020100
 ```

--- a/src/debugger/files.md
+++ b/src/debugger/files.md
@@ -5,5 +5,3 @@ The rizin debugger allows the user to list and manipulate the file descriptors f
 This is a useful feature, which is not found in other debuggers, the functionality is similar to the lsof command line tool, but have extra subcommands to change the seek, close or duplicate them.
 
 So, at any time in the debugging session you can replace the stdio file descriptors to use network sockets created by rizin, or replace a network socket connection to hijack it.
-
-This functionality is also available in `r2frida` by using the dd command prefixed with a backslash. In rizin you may want to see the output of `dd?` for proper details.

--- a/src/debugger/files.md
+++ b/src/debugger/files.md
@@ -6,4 +6,4 @@ This is a useful feature, which is not found in other debuggers, the functionali
 
 So, at any time in the debugging session you can replace the stdio file descriptors to use network sockets created by rizin, or replace a network socket connection to hijack it.
 
-This functionality is also available in r2frida by using the dd command prefixed with a backslash. In rizin you may want to see the output of dd? for proper details.
+This functionality is also available in `r2frida` by using the dd command prefixed with a backslash. In rizin you may want to see the output of `dd?` for proper details.

--- a/src/first_steps/expressions.md
+++ b/src/first_steps/expressions.md
@@ -4,17 +4,53 @@ Expressions are mathematical representations of 64-bit numerical values.
 They can be displayed in different formats, be compared or used with all commands
 accepting numeric arguments. Expressions can use traditional arithmetic operations,
 as well as binary and boolean ones.
-To evaluate mathematical expressions prepend them with command `?`:
+
+To evaluate mathematical expressions prepend them with command `%`:
 ```
-[0xb7f9d810]> ?vi 0x8048000
+[0x00000000]> %?
+Usage: %[?]   # Math commands
+| %[j] <expr>            # Evaluate given numerical expression
+| %$ [<var>]             # Print Rizin variables and their values
+| %0                     # Set first tab as the current active tab
+| %1                     # Set next tab as the current active tab
+| %r <lowlimit> <uplimit> # Generate random number
+| %b[?]                  # Base64 encode/decode and print binary commands
+| %btw <first> <middle> <last> # Check if middle number is between the other two (first and last)
+| %B <mode>              # Get boundaries (start addr, stop addr) of different modes in Core.
+| %h <strs1> <strs2> ... # Print hash value of given input
+| %f <value> <bitstring> # bitstring manipulation.
+| %o <input>             # Evaluate expression and print value in octal.
+| %u <input>             # Convert evaluated numbers/expressions to K, M, G, T etc... units
+| %q <input>             # Update $? (last evaluated expression) without printing anything
+| %v[xi?]                # Show value commands
+| %= <input>             # Replace the value of last evalued expression with given value
+| %== <str1> <str2>      # Compare two given strings and set $? register to cmp result
+| %+ <cmd>               # Execute given command if $? register is greater than 0
+| %- <cmd>               # Execute given command if $? register is less than 0
+| %! <cmd>               # Execute command if result of last numeric expression evaluation (related) command was 0
+| %% <cmd>               # Execute command if result of last numeric expression evaluation (related) command was not 0
+| %l[q] <str>            # Calculate length of string. Quite mode stores value in `$?` register.
+| %X <expr>              # Show evaluated expression in hex
+| %x[+-]                 # String/Numeric to hex manipulation commands
+| %s <start> <stop> <step> # Generate sequence of numbers (?s from to step)
+| %P [<paddr>]           # Convert physical to virtual address
+| %p [<vaddr>]           # Virtual to physical address conversion
+| %_ <input>             # HUD input
+| %i[nykpmf]             # Input commands
+| %w <addr>              # Get references of given address
+```
+
+Some examples:
+```
+[0x00000000]> %vi 0x8048000
 134512640
-[0xv7f9d810]> ?vi 0x8048000+34
+[0x00000000]> %vi 0x8048000+34
 134512674
-[0xb7f9d810]> ?vi 0x8048000+0x34
+[0x00000000]> %vi 0x8048000+0x34
 134512692
-[0x00000000]> ?vi 2**10
+[0x00000000]> %vi 2**10
 1024
-[0xb7f9d810]> ? 1+2+3-4*3
+[0x00000000]> % 1+2+3-4*3
 hex     0xfffffffffffffffa
 octal   01777777777777777777772
 unit    17179869184.0G
@@ -27,6 +63,7 @@ float:  nanf
 double: nan
 trits   0t11112220022122120101211020120210210211201
 ```
+
 Supported arithmetic operations are:
 
  *  \+ : addition
@@ -39,24 +76,27 @@ Supported arithmetic operations are:
  * \*\* : power
 
 ```
-[0x00000000]> ?vi 1+2+3
+[0x00000000]> %vi 1+2+3
 6
 ```
 
-To use of logical OR should quote the whole command to avoid executing the `|` pipe:
+To use of logical OR, you should quote command arguments or escape the character to avoid executing the `|` pipe:
 ```
-[0x00000000]> "? 1 | 2"
+[0x00000000]> % "1 | 2"
+int32   3
+uint32  3
 hex     0x3
 octal   03
 unit    3
 segment 0000:0003
-int32   3
 string  "\x03"
+fvalue  2.0
+float   2.000000f
+double  2.000000
 binary  0b00000011
-fvalue: 2.0
-float:  0.000000f
-double: 0.000000
 trits   0t10
+[0x00000000]> %vi 1 \| 2
+3
 ```
 
 Numbers can be displayed in several formats:
@@ -70,8 +110,7 @@ sym.fo  : resolve flag offset
 
 You can also use variables and seek positions to build complex expressions.
 
-Use the `?$?` command to list all the available commands or read the refcard chapter of this book.
-
+Use the `%$?` command to list all the available commands or read the refcard chapter of this book. Some important variables:
 ```
 $$    here (the current virtual seek)
 $l    opcode length
@@ -84,8 +123,8 @@ $b    block size
 
 Some more examples:
 ```
-[0x4A13B8C0]> ? $m + $l
-140293837812900 0x7f98b45df4a4 03771426427372244 130658.0G 8b45d000:04a4 140293837812900 10100100 140293837812900.0 -0.000000
+[0x4A13B8C0]> %vx $m + $l
+0x7f98b45df4a4
 ```
 ```
 [0x4A13B8C0]> pd 1 @ +$l

--- a/src/refcard/intro.md
+++ b/src/refcard/intro.md
@@ -157,53 +157,61 @@ where the `/` command may search for the given value.
 
 ## Usable variables in expression
 
-The `?$?` command will display the variables that can be used in any math
-operation inside the rizin shell. For example, using the `? $$` command to evaluate
-a number or `?v` to just the value in one format.
+The `%$?` command will display the variables that can be used in any math
+operation inside the rizin shell. For example, using the `% $$` command to evaluate
+a number or `%v` to just the value in one format.
 
 All commands in rizin that accept a number supports the use of those variables.
 
-| Command       | Description                                      |
-|:--------------|:-------------------------------------------------|
-| $$            | here (current virtual seek)|
-| $$$           | current non-temporary virtual seek|
-| $?            | last comparison value|
-| $alias=value  | alias commands (simple macros)|
-| $b            | block size|
-| $B            | base address (aligned lowest map address)|
-| $f            | jump fail address (e.g. jz 0x10 => next instruction)|
-| $fl           | flag length (size) at current address (fla; pD $l @ entry0)|
-| $F            | current function size|
-| $FB           | begin of function|
-| $Fb           | address of the current basic block|
-| $Fs           | size of the current basic block|
-| $FE           | end of function|
-| $FS           | function size|
-| $Fj           | function jump destination|
-| $Ff           | function false destination|
-| $FI           | function instructions|
-| $c,$r         | get width and height of terminal|
-| $Cn           | get nth call of function|
-| $Dn           | get nth data reference in function|
-| $D            | current debug map base address ?v $D @ rsp|
-| $DD           | current debug map size|
-| $e            | 1 if end of block, else 0|
-| $j            | jump address (e.g. jmp 0x10, jz 0x10 => 0x10)|
-| $Ja           | get nth jump of function|
-| $Xn           | get nth xref of function|
-| $l            | opcode length|
-| $m            | opcode memory reference (e.g. mov eax,[0x10] => 0x10)|
-| $M            | map address (lowest map address)|
-| $o            | here (current disk io offset)|
-| $p            | getpid()|
-| $P            | pid of children (only in debug)|
-| $s            | file size|
-| $S            | section offset|
-| $SS           | section size|
-| $v            | opcode immediate value (e.g. lui a0,0x8010 => 0x8010)|
-| $w            | get word size, 4 if asm.bits=32, 8 if 64, ...|
-| ${ev}         | get value of eval config variable|
-| $r{reg}       | get value of named register|
-| $k{kv}        | get value of an sdb query value|
-| $s{flag}      | get size of flag|
-| RzNum        | $variables usable in math expressions|
+| Command       | Description                                                 |
+|:--------------|:------------------------------------------------------------|
+| $$            | here (current virtual seek)                                 |
+| $$$           | current non-temporary virtual seek                          |
+| $?            | last comparison value                                       |
+| $B            | base address (aligned lowest map address)                   |
+| $b            | block size                                                  |
+| $c            | get terminal width in character columns                     |
+| $Cn           | get nth call of function                                    |
+| $D            | current debug map base address ?v $D @ rsp                  |
+| $DB           | same as dbg.baddr, progam base address                      |
+| $DD           | current debug map size                                      |
+| $Dn           | get nth data reference in function                          |
+| $e            | 1 if end of block, else 0                                   |
+| $f            | jump fail address (e.g. jz 0x10 => next instruction)        |
+| $F            | Same as $FB                                                 |
+| $Fb           | begin of basic block                                        |
+| $FB           | begin of function                                           |
+| $Fe           | end of basic block                                          |
+| $FE           | end of function                                             |
+| $Ff           | function false destination                                  |
+| $Fi           | basic block instructions                                    |
+| $FI           | function instructions                                       |
+| $Fj           | function jump destination                                   |
+| $fl           | flag length (size) at current address (fla; pD $l @ entry0) |
+| $FS           | function size (linear length)                               |
+| $Fs           | size of the current basic block                             |
+| $FSS          | function size (sum bb sizes)                                |
+| $j            | jump address (e.g. jmp 0x10, jz 0x10 => 0x10)               |
+| $Ja           | get nth jump of function                                    |
+| $l            | opcode length                                               |
+| $M            | map address (lowest map address)                            |
+| $m            | opcode memory reference (e.g. mov eax,[0x10] => 0x10)       |
+| $MM           | map size (lowest map address)                               |
+| $O            | cursor here (current offset pointed by the cursor)          |
+| $o            | here (current disk io offset)                               |
+| $p            | getpid()                                                    |
+| $P            | pid of children (only in debug)                             |
+| $r            | get console height (in rows, see $c for columns)            |
+| $s            | file size                                                   |
+| $S            | section offset                                              |
+| $SS           | section size                                                |
+| $v            | opcode immediate value (e.g. lui a0,0x8010 => 0x8010)       |
+| $w            | get word size, 4 if asm.bits=32, 8 if 64, ...               |
+| $Xn           | get nth xref of function                                    |
+| flag          | offset of flag                                              |
+| ${ev}         | get value of eval <config variable <ev>                     |
+| $alias        | alias commands (simple macros)                              |
+| $e{flag}      | end of <flag> (flag->offset + flag->size)                   |
+| $k{kv}        | get value of an sdb query value                             |
+| $r{reg}       | get value of named register <reg>                           |
+| $s{flag}      | get size of <flag>                                          |

--- a/src/scripting/intro.md
+++ b/src/scripting/intro.md
@@ -65,7 +65,7 @@ commands
 [0x00404800]> px 10 @ `ao~ptr[1]` >> example.txt
 ```
 
-The `?$?` command describes several helpful variables you can use to do similar actions even more
+The `%$?` command describes several helpful variables you can use to do similar actions even more
 easily, like the `$v` "immediate value" variable, or the `$m` opcode memory reference variable.
 
 

--- a/src/tools/intro.md
+++ b/src/tools/intro.md
@@ -6,7 +6,7 @@ All the functionalities provided by the different APIs and plugins have also dif
 
 Thanks to the orthogonal design of the framework it is possible to do all the things that rizin is able from different places:
 
-* these companion tools
-* native library apis
-* scripting with rz-pipe
-* the rizin shell
+* These companion tools
+* Native library apis
+* Scripting with `rz-pipe`
+* The rizin shell

--- a/src/tools/rz-asm/config.md
+++ b/src/tools/rz-asm/config.md
@@ -4,10 +4,10 @@ The assembler and disassembler have many small switches to tweak the output.
 
 Those configurations are available through the `e` command. Here there are the most common ones:
 
-* asm.bytes - show/hide bytes
-* asm.offset - show/hide offset
-* asm.lines - show/hide lines
-* asm.ucase - show disasm in uppercase
+* `asm.bytes`: Show/hide bytes
+* `asm.offset`: Show/hide offset
+* `asm.lines`: Show/hide lines
+* `asm.ucase`: Show disasm in uppercase
 * ...
 
 Use the `el asm.` for more details.

--- a/src/tools/rz-ax/intro.md
+++ b/src/tools/rz-ax/intro.md
@@ -4,13 +4,13 @@ The `rz-ax` utility comes with the rizin framework and aims to be a minimalistic
 
 This is the help message of rz-ax, this tool can be used in the command-line or interactively (reading the values from stdin), so it can be used as a multi-base calculator.
 
-Inside rizin, the functionality of rz-ax is available under the ? command. For example:
+Inside rizin, the functionality of rz-ax is available under the `%` command. For example:
 
 ```
-[0x00000000]> ? 3+4
+[0x00000000]> % 3+4
 ```
 
-As you can see, the numeric expressions can contain mathematical expressions like addition, subtraction, .. as well as group operations with parenthesis.
+As you can see, the numeric expressions can contain mathematical expressions like addition, subtraction, as well as group operations with parenthesis.
 
 The syntax in which the numbers are represented define the base, for example:
 


### PR DESCRIPTION
Changes:
- Replace outdated use of `?` command for math with new `%` command.
- Add `%?` output to [first_steps/expressions.md](https://github.com/8dcc/rizin-book/blob/4bfefcdd63ca779e9200d67e8070435df0002ae9/src/first_steps/expressions.md?plain=1#L10-L40).
- Add mention of escaped pipe for bitwise or (`\|`).
- Update variables table in [refcard/intro.md](https://github.com/8dcc/rizin-book/blob/4bfefcdd63ca779e9200d67e8070435df0002ae9/src/refcard/intro.md?plain=1#L166-L217).
- Add some missing codeblocks and fix some small grammar typos.

Fixes #99.