### PR TITLE
Update references to the rizinrc config file

### DIFF
--- a/src/configuration/colors.md
+++ b/src/configuration/colors.md
@@ -4,7 +4,7 @@ Console access is wrapped in API that permits to show the output of any command 
 
 To enable colors support by default, add a corresponding configuration option to the .rizin configuration file:
 ```
-$ echo 'e scr.color=1' >> ~/.rizinrc
+$ echo 'e scr.color=1' >> ~/.config/rizin/rizinrc
 ```
 Note that enabling colors is not a boolean option. Instead, it is a number because there are different color depth levels. This is:
 

--- a/src/configuration/evars.md
+++ b/src/configuration/evars.md
@@ -348,7 +348,7 @@ Rizin also supports custom fortunes. You can save your fortunes in a file and pr
 [0x00000000]> e cfg.fortunes.file=/path/to/my/fortunes.txt
 ```
 
-Please make sure that you add these in your `~/.rizinrc` to preserve the changes when you reopen rizin.
+Please make sure that you add these in your `~/.config/rizin/rizinrc` to preserve the changes when you reopen rizin.
 
 ### cfg.newtab: `bool`
 

--- a/src/configuration/intro.md
+++ b/src/configuration/intro.md
@@ -6,11 +6,11 @@ To prevent rizin from parsing this file at startup, pass it the `-N` option.
 
 All the configuration of rizin is done with the `eval` commands. A typical startup configuration file looks like this:
 ```sh
-$ cat ~/.rizinrc
+$ cat ~/.config/rizin/rizinrc
 e scr.color=1
 e dbg.bep   = loader
 ```
-The configuration can also be changed with `-e` <config=value> command-line option. This way you can adjust configuration from the command line, keeping the .rizinrc file intact. For example, to start with empty configuration and then adjust `scr.color` and `asm.syntax` the following line may be used:
+The configuration can also be changed with `-e` <config=value> command-line option. This way you can adjust configuration from the command line, keeping the `~/.config/rizin/rizinrc` file intact. For example, to start with empty configuration and then adjust `scr.color` and `asm.syntax` the following line may be used:
 ```sh
 $ rizin -N -e scr.color=1 -e asm.syntax=intel -d /bin/ls
 ```

--- a/src/configuration/intro.md
+++ b/src/configuration/intro.md
@@ -27,14 +27,12 @@ Usage: e[?]   # List/get/set config evaluable vars
 | e <key>[=<val|?>] [<key>[=<val|?>] ...]] # Get/Set value of config variable <key>
 | el[j*qlJ] [<key>]      # List config variables with their descriptions
 | e-                     # Reset config variables
-| e! <key>               # Invert the boolean value of config variable <var>
+| e! <key>               # Invert the boolean value of config variable <key>
 | ec[?]                  # Set color for given key (prompt, offset, ...)
-| ee <key>               # Open editor to change the value of config variable <var>
-| ed                     # Open editor to change ~/.rizinrc
-| er <key>               # Set config variable <var> as read-only
+| ee <key>               # Open editor to change the value of config variable <key>
+| er <key>               # Set config variable <key> as read-only
 | es [<key>]             # List all config variable spaces or sub-keys/sub-spaces if a <key> is provided
-| et <key>               # Show type of given config variable <var>
-| env [<varname>[=<varvalue>]] # Get/set environment variables
+| et <key>               # Show type of given config variable <key>
 ```
 
 A simpler alternative to the `e` command is accessible from the visual mode. Type `Ve` to enter it, use arrows (up, down, left, right) to navigate the configuration, and `q` to exit it. The start screen for the visual configuration edit looks like this:


### PR DESCRIPTION
I started out PR'ing this to `dev`, but it seems like there's a few outstanding commits and the last two PR's have gone straight to `master`, so this too is set to `master`, but let me know if you want me to rebase on `dev`.

Updated a few references of `~/.rizinrc` to be `~/.config/rizin/rizinrc`. Both do appear to work, but thought it would be nice to be consistent. One of the instances was an old output of the command `e?` which I've also included an update for.