### PR TITLE
Update syscall examples

### DIFF
--- a/src/analysis/syscalls.md
+++ b/src/analysis/syscalls.md
@@ -93,12 +93,10 @@ child stopped with signal 133
 rizin also has a syscall name to syscall number utility. You can return the syscall name of a given syscall number or vice versa, without leaving the shell.
 
 ```
-[0x08048436]> asl 1
+[0x08048436]> asr 1
 exit
-[0x08048436]> asl write
+[0x08048436]> asn write
 4
-[0x08048436]> ask write
-0x80,4,3,iZi
 ```
 
 See `as?` for more information about the utility.


### PR DESCRIPTION
PR #2323 [1] removed `ask` command and `asl` does not accept an argument any more. Instead there are two new commands `asn` and `asr` to query for number or name respectively.

[1] https://github.com/rizinorg/rizin/pull/2323