### PR TITLE
Update expressions.md

### DIFF
--- a/src/first_steps/expressions.md
+++ b/src/first_steps/expressions.md
@@ -4,27 +4,28 @@ Expressions are mathematical representations of 64-bit numerical values.
 They can be displayed in different formats, be compared or used with all commands
 accepting numeric arguments. Expressions can use traditional arithmetic operations,
 as well as binary and boolean ones.
-To evaluate mathematical expressions prepend them with command `?`:
+To evaluate mathematical expressions prepend them with command `%`:
 ```
-[0xb7f9d810]> ?vi 0x8048000
+[0xb7f9d810]> %vi 0x8048000
 134512640
-[0xv7f9d810]> ?vi 0x8048000+34
+[0xv7f9d810]> %vi 0x8048000+34
 134512674
-[0xb7f9d810]> ?vi 0x8048000+0x34
+[0xb7f9d810]> %vi 0x8048000+0x34
 134512692
-[0x00000000]> ?vi 2**10
+[0x00000000]> %vi 2**10
 1024
-[0xb7f9d810]> ? 1+2+3-4*3
+[0xb7f9d810]> % 1+2+3-4*3
+int64   -6
+uint64  18446744073709551610
 hex     0xfffffffffffffffa
 octal   01777777777777777777772
-unit    17179869184.0G
+unit    16E
 segment fffff000:0ffa
-int64   -6
 string  "\xfa\xff\xff\xff\xff\xff\xff\xff"
+fvalue  -6.0
+float   -6.000000f
+double  -6.000000
 binary  0b1111111111111111111111111111111111111111111111111111111111111010
-fvalue: -6.0
-float:  nanf
-double: nan
 trits   0t11112220022122120101211020120210210211201
 ```
 Supported arithmetic operations are:
@@ -39,23 +40,24 @@ Supported arithmetic operations are:
  * \*\* : power
 
 ```
-[0x00000000]> ?vi 1+2+3
+[0x00000000]> %vi 1+2+3
 6
 ```
 
-To use of logical OR should quote the whole command to avoid executing the `|` pipe:
+Enclose the expression with double quotes to evaluate `|` as logical OR instead of pipe command.
 ```
-[0x00000000]> "? 1 | 2"
+[0x00000000]> % "1 | 2"
+int32   3
+uint32  3
 hex     0x3
 octal   03
 unit    3
 segment 0000:0003
-int32   3
 string  "\x03"
+fvalue  2.0
+float   2.000000f
+double  2.000000
 binary  0b00000011
-fvalue: 2.0
-float:  0.000000f
-double: 0.000000
 trits   0t10
 ```
 
@@ -70,7 +72,7 @@ sym.fo  : resolve flag offset
 
 You can also use variables and seek positions to build complex expressions.
 
-Use the `?$?` command to list all the available commands or read the refcard chapter of this book.
+Use the `%$?` command to list all the available commands or read the refcard chapter of this book.
 
 ```
 $$    here (the current virtual seek)
@@ -84,7 +86,7 @@ $b    block size
 
 Some more examples:
 ```
-[0x4A13B8C0]> ? $m + $l
+[0x4A13B8C0]> % $m + $l
 140293837812900 0x7f98b45df4a4 03771426427372244 130658.0G 8b45d000:04a4 140293837812900 10100100 140293837812900.0 -0.000000
 ```
 ```


### PR DESCRIPTION
Fixes #107 

Changed all occurrences of the expression command from '?' to '%'. Updated outputs of commands to reflect current behavior. Fixed logical OR quotation syntax and cleaned up verbiage.