### PR TITLE
IOLI Crackme improvements/updates

### DIFF
--- a/src/crackmes/ioli/ioli_0x00.md
+++ b/src/crackmes/ioli/ioli_0x00.md
@@ -24,7 +24,7 @@ nth paddr      vaddr      len size section type  string
 4   0x000005a9 0x080485a9 15  16   .rodata ascii Password OK :)\n
 ```
 
-So we know what the following section is, this section is the header shown when the application is run.
+So we know what the following section is: this section is the header shown when the application is run.
 
 ```
 nth paddr      vaddr      len size section type  string

--- a/src/crackmes/ioli/ioli_0x04.md
+++ b/src/crackmes/ioli/ioli_0x04.md
@@ -1,108 +1,198 @@
 IOLI 0x04
 =========
 
-# 0x04
-
-```C
-[0x080483d0]> pdd@main
-/* jsdec pseudo code output */
-/* ./crackme0x04 @ 0x8048509 */
-#include <stdint.h>
-
-int32_t main (void) {
-    int32_t var_78h;
-    int32_t var_4h;
-    eax = 0;
-    eax += 0xf;
-    eax += 0xf;
-    eax >>= 4;
-    eax <<= 4;
-    printf ("IOLI Crackme Level 0x04\n");
-    printf ("Password: ");
-    eax = &var_78h;
-    scanf (0x8048682, eax);
-    eax = &var_78h;
-    check (eax);
-    eax = 0;
-    return eax;
-}
-```
-
-Let's enter check.
-
-```C
-#include <stdint.h>
-
-int32_t check (char * s) {
-    char * var_dh;
-    uint32_t var_ch;
-    uint32_t var_8h;
-    int32_t var_4h;
-    char * format;
-    int32_t var_sp_8h;
-    var_8h = 0;
-    var_ch = 0;
-    do {
-        eax = s;
-        eax = strlen (eax);
-        if (var_ch >= eax) {
-            goto label_0;
-        }
-        eax = var_ch;
-        eax += s;
-        eax = *(eax);
-        var_dh = al;
-        eax = &var_4h;
-        eax = &var_dh;
-        sscanf (eax, eax, 0x8048638);
-        edx = var_4h;
-        eax = &var_8h;
-        *(eax) += edx;
-        if (var_8h == 0xf) {
-            printf ("Password OK!\n");
-            exit (0);
-        }
-        eax = &var_ch;
-        *(eax)++;
-    } while (1);
-label_0:
-    printf ("Password Incorrect!\n");
-    return eax;
-}
-```
-
-manually analyze with both the assembly and pseudo code we can simply write down the C-like code to describe this function:
-
-```C
-#include <stdint.h>
-int32_t check(char *s)
-{
-    var_ch = 0;
-    var_8h = 0;
-    for (var_ch = 0; var_ch < strlen(s); ++var_ch)
-    {
-        var_dh = s[var_ch];
-        sscanf(&var_dh, %d, &var_4h);			// read from string[var_ch], store to var_4h
-        var_8h += var_4h;
-        if(var_8h == 0xf)
-            printf("Password OK\n");
-    }
-    printf("Password Incorrect!\n");
-    return 0;
-}
-```
-
-In short, it calculates the Digit Sum of a number (add a number digit by digit. for example, 96 => 9 + 6 = 15) :
+This is the fifth crackme.
 
 ```bash
-./crackme0x04
+$ rz-bin -z ./crackme0x04
+[Strings]
+nth paddr      vaddr      len size section type  string                    
+---------------------------------------------------------------------------
+0   0x0000063b 0x0804863b 13  14   .rodata ascii Password OK!\n
+1   0x00000649 0x08048649 20  21   .rodata ascii Password Incorrect!\n
+2   0x0000065e 0x0804865e 24  25   .rodata ascii IOLI Crackme Level 0x04\n
+3   0x00000677 0x08048677 10  11   .rodata ascii Password: 
+```
+
+Checking for strings we see that our old friends "Password OK!" and "Password Incorrect!" are back in their unobfuscated
+forms.
+
+```c
+$ rizin ./crackme0x04
+[0x080483d0]> aaa
+[0x080483d0]> pdg @ main
+
+undefined4 main(void)
+{
+    int32_t var_88h;
+    int32_t var_7ch;
+    
+    sym.imp.printf("IOLI Crackme Level 0x04\n");
+    sym.imp.printf("Password: ");
+    sym.imp.scanf(data.08048682, &var_7ch);
+    sym.check((char *)&var_7ch);
+    return 0;
+}
+[0x080483d0]> ps @ data.08048682 
+%s
+```
+
+This time though, `scanf` takes a *string* and passes it to a function called `check`.
+
+```c
+[0x080483d0]> pdg @ sym.check
+// WARNING: Variable defined which should be unmapped: var_28h
+// WARNING: Variable defined which should be unmapped: var_24h
+// WARNING: [rz-ghidra] Detected overlap for variable var_11h
+
+void sym.check(int32_t arg_4h)
+{
+    uint32_t uVar1;
+    int32_t var_28h;
+    int32_t var_24h;
+    undefined var_11h;
+    int32_t var_10h;
+    int32_t var_ch;
+    int32_t var_8h;
+    
+    var_ch = 0;
+    var_10h = 0;
+    while( true ) {
+        uVar1 = sym.imp.strlen(arg_4h);
+        if (uVar1 <= (uint32_t)var_10h) break;
+        var_11h = *(undefined *)(var_10h + arg_4h);
+        sym.imp.sscanf(&var_11h, 0x8048638, &var_8h);
+        var_ch = var_ch + var_8h;
+        if (var_ch == 0xf) {
+            sym.imp.printf("Password OK!\n");
+            sym.imp.exit(0);
+        }
+        var_10h = var_10h + 1;
+    }
+    sym.imp.printf("Password Incorrect!\n");
+    return;
+}
+[0x080483d0]> afvl @ sym.check
+var int32_t var_28h @ stack - 0x28
+var int32_t var_24h @ stack - 0x24
+var int32_t var_11h @ stack - 0x11
+var int32_t var_10h @ stack - 0x10
+var int32_t var_ch @ stack - 0xc
+var int32_t var_8h @ stack - 0x8
+arg int32_t arg_4h @ stack + 0x4
+[0x080483d0]> ps @ 0x8048638 @!2
+%d
+```
+
+A few things to note: `sscanf` in the `while` loop takes an integer ("%d"), and the result is placed in
+`var_8h`, which is subsequently used to increment `var_ch`. As soon as `var_ch` equals 15 (0xf) we gain
+entry.
+
+Other than that however it may not be very obvious at first glance what exactly is going on here. So let's start a debugging session
+to execute the function.
+
+```bash
+$ rizin -d ./crackme0x04
+[0xf3666cd0]> aaa
+[0xf3666cd0]> dcu main          # execute until start of `main`
+[0x08048509]> dr eip=sym.check  # instruction pointer to start of `check`
+```
+
+We will want to pass our own strings to `check`, so let's allocate some memory and write a string to it.
+
+```bash
+[0x08048509]> dm+ 512 @ -1              # Allocate 512 bytes at anywhere (-1)
+ra0=0xf3643000
+[0x08048509]> wz "letmein" @ 0xf3643000 # Write null-terminated string to our allocated memory
+[0x08048509]> *esp+4=0xf3643000         # store the address under `arg_4h` (stack + 0x04)
+```
+
+The password check completes if `var_ch` equals 15 (0xf) so let's add a breakpoint that prints the
+value of `var_ch`. We are going to be putting the breakpoint at the comparison of `var_ch` and `0xf`,
+try to find it using `pdf @ sym.check`.
+
+```bash
+[0x08048508]> pdf @ sym.check # find `cmp dword [var_ch], 0xf` 
+...
+[0x08048508]> db @ 0x080484d6                       # set breakpoint
+[0x08048508]> dbc 'pxw 1 @ esp-0xc' @ 0x080484d6    # execute command on break
+[0x08048508]> dcr                                   # execute until return
+0xffa833f0  0x00000004                                   . # l
+0xffa833f0  0x00000008                                   . # e
+0xffa833f0  0x0000000c                                   . # t
+0xffa833f0  0x00000010                                   . # m
+0xffa833f0  0x00000014                                   . # e
+0xffa833f0  0x00000018                                   . # i
+0xffa833f0  0x0000001c                                   . # n
+Password Incorrect!
+```
+
+We can see that each letter increments `var_ch` by 4. Remember that `sscanf` in `check` takes a number (%d) as input. And
+because we didn't provide any numbers, odds are that '4' was probably some leftover data that happend to sit at the location
+of `var_ch`. This was never overwritten because `sscanf` didn't encounter any numbers.
+
+So let's try giving it a number as input.
+
+```bash
+[0x08048508]> wz "1234" @ 0xf3643010
+[0x08048508]> *esp+4=0xf3643010
+[0x08048508]> dr eip=sym.check
+[0x08048508]> dcr
+0xffa833f0  0x00000001                                   . # 1
+0xffa833f0  0x00000003                                   . # 2
+0xffa833f0  0x00000006                                   . # 3
+0xffa833f0  0x0000000a                                   . # 4
+Password Incorrect!
+```
+
+Now we see what the function `check` is actually supposed to do: it increments the counter
+by each digit encountered. Or in other words it computes the digit sum, which has to land on 15 at some point during
+the computation.
+
+And indeed, cleaning up the decompiled `check` makes this more obvious.
+
+```c
+void sym.check(char *s)
+{
+    int32_t var_11h = 0;
+    int32_t sum = 0;
+    int32_t d;
+
+    for(int i = 0; i < strlen(s); i++) {
+        var_11h = s[i];
+        sscanf(&var_11h, "%d", &d);
+        sum += d;
+        if(sum == 0xf) {
+            printf("Password OK!\n");
+            exit(0);
+        }
+    }
+    printf("Password Incorrect!\n");
+    return;
+}
+```
+
+```bash
+$ ./crackme0x04
 IOLI Crackme Level 0x04
 Password: 12345
 Password OK!
 
-./crackme0x04
+$ ./crackme0x04
 IOLI Crackme Level 0x04
 Password: 96
 Password OK!
 ```
 
+Using what we discovered when we entered non-digit characters we can get some other passwords to work as well.
+```bash
+$ ./crackme0x04
+IOLI Crackme Level 0x04
+Password: 5asdf
+Password OK!
+
+$ ./crackme0x04
+IOLI Crackme Level 0x04
+Password: 0this-will-not-increment1but-this-will:)
+Password OK!
+```

--- a/src/crackmes/ioli/ioli_0x06.md
+++ b/src/crackmes/ioli/ioli_0x06.md
@@ -1,230 +1,246 @@
 IOLI 0x06
 =========
 
-nearly a routine to check this binary (not complete output in the following):
+Onto the seventh crackme.
 
-```bash
-rz-bin -z ./crackme0x06
+```
+$ rz-bin -z ./crackme0x06
 [Strings]
-nth paddr      vaddr      len size section type  string
-―――――――――――――――――――――――――――――――――――――――――――――――――――――――
+nth paddr      vaddr      len size section type  string                    
+---------------------------------------------------------------------------
 0   0x00000738 0x08048738 4   5    .rodata ascii LOLO
 1   0x00000740 0x08048740 13  14   .rodata ascii Password OK!\n
 2   0x0000074e 0x0804874e 20  21   .rodata ascii Password Incorrect!\n
 3   0x00000763 0x08048763 24  25   .rodata ascii IOLI Crackme Level 0x06\n
-4   0x0000077c 0x0804877c 10  11   .rodata ascii Password:
-
-rz-bin -I ./crackme0x06
-arch     x86
-baddr    0x8048000
-bintype  elf
-bits     32
-compiler GCC: (GNU) 3.4.6 (Gentoo 3.4.6-r2, ssp-3.4.6-1.0, pie-8.7.10)
-crypto   false
-endian   little
-havecode true
-lang     c
-machine  Intel 80386
-maxopsz  16
-minopsz  1
-os       linux
-static   false
-va       true
+4   0x0000077c 0x0804877c 10  11   .rodata ascii Password: 
 ```
 
-and analyze it then decompile main
-
-```C
-[0x08048400]> pdd@main
-/* jsdec pseudo code output */
-/* ./crackme0x06 @ 0x8048607 */
-#include <stdint.h>
-
-int32_t main (int32_t arg_10h) {
-    int32_t var_78h;
-    int32_t var_4h;
-    // adjusting stack
-    eax = 0;
-    eax += 0xf;
-    eax += 0xf;
-    eax >>= 4;
-    eax <<= 4;
-
-    // main logic
-    printf ("IOLI Crackme Level 0x06\n");
-    printf ("Password: ");
-    eax = &var_78h;
-    scanf (0x8048787, eax);
-    eax = arg_10h;
-    eax = &var_78h;
-    check (eax, arg_10h);
-    eax = 0;
-    return eax;
-}
-```
-
-main has 3 arguments `argc, argv, envp`, and this program is compiled with GCC, so the stack should be like this :
-
-```bash
-[esp + 0x10] - envp
-[esp + 0x0c] - argv
-[esp + 0x08] - argc
-[esp + 0x04] - return address
-```
-
-enter the `check()` and decompile it. this function is different from 0x05 now. but they still have similar code structure.
-
-```C
-int32_t check (char * s, int32_t arg_ch) {
-    char * var_dh;
-    uint32_t var_ch;
-    uint32_t var_8h;
-    int32_t var_4h;
-    char * format;
-    int32_t var_sp_8h;
-    var_8h = 0;
-    var_ch = 0;
-    do {
-        eax = s;
-        eax = strlen (eax);
-        if (var_ch >= eax) {
-            goto label_0;
-        }
-        eax = var_ch;
-        eax += s;
-        eax = *(eax);
-        var_dh = al;
-        eax = &var_4h;
-        eax = &var_dh;
-        sscanf (eax, eax, 0x804873d);
-        edx = var_4h;
-        eax = &var_8h;
-        *(eax) += edx;
-        if (var_8h == 0x10) {
-            eax = arg_ch;
-            eax = s;
-            parell (eax, arg_ch);
-        }
-        eax = &var_ch;
-        *(eax)++;
-    } while (1);
-label_0:
-    printf ("Password Incorrect!\n");
-    return eax;
-}
-```
-
-Correct the `sscanf` part and `parell` part, both of them were generated incorrectly:
-
-```C
-int32_t check (char * s, void* envp)
-{
-    var_ch = 0;
-    var_8h = 0;
-    for (var_ch = 0; var_ch < strlen(s); ++var_ch)
-    {
-        var_dh = s[var_ch];
-        sscanf(&var_dh, %d, &var_4h);			// read from string[var_ch], store to var_4h
-        var_8h += var_4h;
-        if(var_8h == 0x10)
-            parell(s, envp);
-    }
-    printf("Password Incorrect!\n");
-    return 0;
-}
-```
-
- no more info, we have to reverse `parell()` again.
-
-```C
-#include <stdint.h>
-
-uint32_t parell (char * s, char * arg_ch) {
-    sscanf (s, %d, &var_4h);
-
-    if (dummy (var_4h, arg_ch) == 0)
-        return 0;
-
-    for (var_bp_8h = 0; var_bp_8h <= 9; ++var_bp_8h){
-        if (var_4h & 1 == 0){
-            printf("Password OK!\n");
-            exit(0);
-        }
-    }
-
-    return 0;
-}
-```
-
-well, there is a new check condition in `parell()` -- `dummy (var_4h, arg_ch) == 0`. then reverse dummy!
-
-```C
-[0x080484b4]> pdd@sym.dummy
-/* jsdec pseudo code output */
-/* ./crackme0x06 @ 0x80484b4 */
-#include <stdint.h>
-
-int32_t dummy (char ** s1) {
-    int32_t var_8h;
-    int32_t var_4h;
-    char * s2;
-    size_t * n;
-    var_4h = 0;
-    do {
-        eax = 0;
-        edx = eax*4;
-        eax = s1;
-        if (*((edx + eax)) == 0) {
-            goto label_0;
-        }
-        eax = var_4h;
-        ecx = eax*4;
-        edx = s1;
-        eax = &var_4h;
-        *(eax)++;
-        eax = *((ecx + edx));
-        eax = strncmp (eax, 3, "LOLO");
-    } while (eax != 0);
-    var_8h = 1;
-    goto label_1;
-label_0:
-    var_8h = 0;
-label_1:
-    eax = 0;
-    return eax;
-}
-```
-
-looks like a loop to process string. we can beautify it.
-
-```C
-[0x080484b4]> pdd@sym.dummy
-/* jsdec pseudo code output */
-/* ./crackme0x06 @ 0x80484b4 */
-#include <stdint.h>
-
-int32_t dummy (char ** s1) {
-    for (var_4h = 0; strncmp(s1[var_4h], "LOLO", 3) != 0; var_4h++){
-        if (s1[i] == NULL)
-            return 0;
-    }
-    return 1;
-}
-```
-
-There are 3 constraints to crackme_0x06:
-
-* Digit Sum
-* Odd Number
-* should have an environment variable whose name started with "LOL".
+Doing our routine strings check we can see a new contender: `LOLO`.
 
 ```bash
 $ ./crackme0x06
 IOLI Crackme Level 0x06
-Password: 12346
+Password: LOLO
 Password Incorrect!
-$ export LOLAA=help
-$ ./cracke0x06
+```
+
+No dice, so let's take a closer look.
+
+```c
+[0x08048400]> pdg @ main
+
+// WARNING: [rz-ghidra] Detected overlap for variable var_11h
+
+undefined4 main(undefined4 placeholder_0, undefined4 placeholder_1, char **envp)
+{
+    int32_t var_88h;
+    int32_t var_7ch;
+    
+    sym.imp.printf("IOLI Crackme Level 0x06\n");
+    sym.imp.printf("Password: ");
+    sym.imp.scanf(0x8048787, &var_7ch);
+    sym.check((int32_t)&var_7ch, (int32_t)envp);
+    return 0;
+}
+[0x08048400]> ps @ 0x8048787
+%s
+[0x08048400]> afvl @ main
+var int32_t var_88h @ stack - 0x88
+var int32_t var_7ch @ stack - 0x7c
+arg char **envp @ stack + 0xc
+```
+
+This looks the same as before, except the program's environment variables `envp` are passed to `check`.
+
+```c
+[0x08048400]> pdg @ sym.check
+
+// WARNING: Variable defined which should be unmapped: var_28h
+// WARNING: Variable defined which should be unmapped: var_24h
+// WARNING: [rz-ghidra] Detected overlap for variable var_11h
+
+void sym.check(int32_t arg_4h, int32_t arg_8h)
+{
+    uint32_t uVar1;
+    int32_t var_28h;
+    int32_t var_24h;
+    undefined var_11h;
+    int32_t var_10h;
+    int32_t var_ch;
+    int32_t var_8h;
+    
+    var_ch = 0;
+    var_10h = 0;
+    while( true ) {
+        uVar1 = sym.imp.strlen(arg_4h);
+        if (uVar1 <= (uint32_t)var_10h) break;
+        var_11h = *(undefined *)(var_10h + arg_4h);
+        sym.imp.sscanf(&var_11h, 0x804873d, &var_8h);
+        var_ch = var_ch + var_8h;
+        if (var_ch == 0x10) {
+            sym.parell(arg_4h, arg_8h);
+        }
+        var_10h = var_10h + 1;
+    }
+    sym.imp.printf("Password Incorrect!\n");
+    return;
+}
+```
+
+This looks mostly the same as well. If we follow `envp` (now named `arg_8h`) we can see it gets passed to
+`parell`.
+
+```c
+[0x08048400]> pdg @ sym.parell
+
+// WARNING: Variable defined which should be unmapped: var_18h
+// WARNING: Variable defined which should be unmapped: var_14h
+
+void sym.parell(int32_t arg_4h, int32_t arg_8h)
+{
+    int32_t iVar1;
+    int32_t var_18h;
+    int32_t var_14h;
+    int32_t var_ch;
+    int32_t var_8h;
+    
+    sym.imp.sscanf(arg_4h, 0x804873d, &var_8h);
+    iVar1 = sym.dummy(var_8h, arg_8h);
+    if (iVar1 != 0) {
+        for (var_ch = 0; var_ch < 10; var_ch = var_ch + 1) {
+            if ((var_8h & 1U) == 0) {
+                sym.imp.printf("Password OK!\n");
+                sym.imp.exit(0);
+            }
+        }
+    }
+    return;
+}
+```
+
+We can see that the parity check is still in place, except it's now in a loop that executes 10 times, but only
+if `dummy()` returns non-zero.
+
+```c
+[0x08048400]> pdg @ sym.dummy
+
+// WARNING: Variable defined which should be unmapped: var_18h
+// WARNING: Variable defined which should be unmapped: var_14h
+
+undefined4 sym.dummy(undefined4 placeholder_0, int32_t arg_8h)
+{
+    int32_t iVar1;
+    int32_t var_18h;
+    int32_t var_14h;
+    int32_t var_ch;
+    int32_t var_8h;
+    
+    var_8h = 0;
+    do {
+        if (*(int32_t *)(var_8h * 4 + arg_8h) == 0) {
+            return 0;
+        }
+        iVar1 = var_8h * 4;
+        var_8h = var_8h + 1;
+        iVar1 = sym.imp.strncmp(*(undefined4 *)(iVar1 + arg_8h), "LOLO", 3);
+    } while (iVar1 != 0);
+    return 1;
+}
+```
+
+Living up to its name, `dummy` does not use its first parameter at all, only the second one is used which is the
+`envp` parameter from `main`. Apparently some part of `envp` has to equal "LOL" (only the first 3 characters are used, note the '3'
+in `strncmp`).
+
+It will be easier to figure out how `dummy` works if we run the code, so let's use the debugger again!
+
+
+```bash
+$ rizin -d ./crackme0x06
+[0xe8570cd0]> aa
+[0xe8570cd0]> dcu sym.dummy
+Continue until 0x080484b4
+IOLI Crackme Level 0x06
+Password: 88
+hit breakpoint at: 0x80484b4
+```
+
+Now we should be at the start of `dummy`, let's see where we can place a breakpoint.
+
+```asm
+[0x08048502]> pdf
+            ; CALL XREF from sym.parell @ 0x8048547
+┌ sym.dummy(int32_t arg_8h);
+│           ; var int32_t var_18h @ stack - 0x18
+│           ; var int32_t var_14h @ stack - 0x14
+│           ; var int32_t var_ch @ stack - 0xc
+│           ; var int32_t var_8h @ stack - 0x8
+│           ; arg int32_t arg_8h @ stack + 0x8
+│           0x080484b4      push  ebp
+│           0x080484b5      mov   ebp, esp
+│           0x080484b7      sub   esp, 0x18
+│           0x080484ba      mov   dword [var_8h], 0
+│       ┌─> 0x080484c1      mov   eax, dword [var_8h]
+│       ╎   0x080484c4      lea   edx, [eax*4]
+│       ╎   0x080484cb      mov   eax, dword [arg_8h]
+│       ╎   0x080484ce      cmp   dword [edx + eax], 0
+│      ┌──< 0x080484d2      je    0x804850e
+│      │╎   0x080484d4      mov   eax, dword [var_8h]
+│      │╎   0x080484d7      lea   ecx, [eax*4]
+│      │╎   0x080484de      mov   edx, dword [arg_8h]
+│      │╎   0x080484e1      lea   eax, [var_8h]
+│      │╎   0x080484e4      inc   dword [eax]
+│      │╎   0x080484e6      mov   dword [var_14h], 3
+│      │╎   0x080484ee      mov   dword [var_18h], 0x8048738           ; str.LOLO
+│      │╎                                                              ; [0x8048738:4]=0x4f4c4f4c ; "LOLO"
+│      │╎   0x080484f6      mov   eax, dword [ecx + edx]
+│      │╎   ;-- eip:
+│      │╎   0x080484f9      mov   dword [esp], eax
+│      │╎   0x080484fc      call  sym.imp.strncmp                      ; sym.imp.strncmp ; int strncmp(const char *s1, const char *s2, size_t n)
+│      │╎   0x08048501      test  eax, eax
+│      │└─< 0x08048503      jne   0x80484c1
+│      │    0x08048505      mov   dword [var_ch], 1
+│      │┌─< 0x0804850c      jmp   0x8048515
+│      └──> 0x0804850e      mov   dword [var_ch], 0
+│       │   ; CODE XREF from sym.dummy @ 0x804850c
+│       └─> 0x08048515      mov   eax, dword [var_ch]
+│           0x08048518      leave
+└           0x08048519      ret
+```
+
+
+The instruction at `0x080484f9` looks like a good spot. This is just before `strncmp` is called, so we can see
+what value is passed to it.
+
+```bash
+[0x08048502]> db @ 0x080484f9
+[0x08048502]> dbc 'psi @r:eax' @ 0x080484f9
+[0x08048502]> dcr
+PWD=/home/rizin
+HOME=/home/rizin
+USER=rizin
+PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
+SHELL=/usr/bin/sh
+```
+
+Running `dcr` you should be greeted with all the environment variables passed to the program.
+From this we can safely conclude that `dummy` is looking for an environment variable starting with "LOL",
+so let's try it.
+
+Remember that there are 3 constraints to the password now:
+
+- Digit sum reaches 16 at some point
+- The number is even
+- An environment variable starting with "LOL" is set
+
+
+```bash
+$ LOL= ./crackme0x06
+IOLI Crackme Level 0x06
+Password: 88
+Password OK!
+
+$ LOL= ./crackme0x06
 IOLI Crackme Level 0x06
 Password: 12346
 Password OK!

--- a/src/crackmes/ioli/ioli_0x08.md
+++ b/src/crackmes/ioli/ioli_0x08.md
@@ -1,42 +1,82 @@
 IOLI 0x08
 =========
 
-we can reverse it and find it's similar to 0x07, and use the same password to solve it:
+Time for the ninth crackme.
+
+```
+$ rz-bin -z ./crackme0x08
+[Strings]
+nth paddr      vaddr      len size section type  string                    
+---------------------------------------------------------------------------
+0   0x000007a8 0x080487a8 4   5    .rodata ascii LOLO
+1   0x000007ad 0x080487ad 20  21   .rodata ascii Password Incorrect!\n
+2   0x000007c5 0x080487c5 13  14   .rodata ascii Password OK!\n
+3   0x000007d3 0x080487d3 5   6    .rodata ascii wtf?\n
+4   0x000007d9 0x080487d9 24  25   .rodata ascii IOLI Crackme Level 0x08\n
+5   0x000007f2 0x080487f2 10  11   .rodata ascii Password:
+```
+
+It looks like no new strings have been added. Before we jump into analyzing however, let's first see which functions have changed from the
+previous version. We can get a nice overview using `rz-diff`.
+
+```diff
+$ rz-diff -t functions crackme0x07 crackme0x08
+.--------------------------------------------------------------------------------------------------------------------------.
+| name0                     | size0 | addr0      | type     | similarity | addr1      | size1 | name1                      |
+)--------------------------------------------------------------------------------------------------------------------------(
+| fcn.08048360              | 23    | 0x08048360 | COMPLETE | 1.000000   | 0x08048360 | 23    | sym._init                  |
+| sym.imp.__libc_start_main | 6     | 0x08048388 | COMPLETE | 1.000000   | 0x08048388 | 6     | sym.imp.__libc_start_main  |
+| sym.imp.scanf             | 6     | 0x08048398 | COMPLETE | 1.000000   | 0x08048398 | 6     | sym.imp.scanf              |
+| sym.imp.strlen            | 6     | 0x080483a8 | COMPLETE | 1.000000   | 0x080483a8 | 6     | sym.imp.strlen             |
+| sym.imp.printf            | 6     | 0x080483b8 | COMPLETE | 1.000000   | 0x080483b8 | 6     | sym.imp.printf             |
+| sym.imp.sscanf            | 6     | 0x080483c8 | COMPLETE | 1.000000   | 0x080483c8 | 6     | sym.imp.sscanf             |
+| sym.imp.strncmp           | 6     | 0x080483d8 | COMPLETE | 1.000000   | 0x080483d8 | 6     | sym.imp.strncmp            |
+| sym.imp.exit              | 6     | 0x080483e8 | COMPLETE | 1.000000   | 0x080483e8 | 6     | sym.imp.exit               |
+| fcn.08048424              | 33    | 0x08048424 | COMPLETE | 1.000000   | 0x08048424 | 33    | fcn.08048424               |
+| fcn.08048450              | 47    | 0x08048450 | COMPLETE | 1.000000   | 0x08048450 | 47    | sym.__do_global_dtors_aux  |
+| fcn.08048480              | 50    | 0x08048480 | COMPLETE | 1.000000   | 0x08048480 | 50    | sym.frame_dummy            |
+| fcn.080484b4              | 112   | 0x080484b4 | COMPLETE | 1.000000   | 0x080484b4 | 112   | sym.dummy                  |
+| fcn.08048524              | 30    | 0x08048524 | COMPLETE | 1.000000   | 0x08048524 | 30    | sym.che                    |
+| fcn.08048542              | 119   | 0x08048542 | COMPLETE | 1.000000   | 0x08048542 | 119   | sym.parell                 |
+| fcn.080485b9              | 118   | 0x080485b9 | COMPLETE | 1.000000   | 0x080485b9 | 118   | sym.check                  |
+| fcn.08048755              | 4     | 0x08048755 | COMPLETE | 1.000000   | 0x08048755 | 4     | sym.__i686.get_pc_thunk.bx |
+| fcn.08048760              | 35    | 0x08048760 | COMPLETE | 1.000000   | 0x08048760 | 35    | sym.__do_global_ctors_aux  |
+| fcn.0804878d              | 17    | 0x0804878d | COMPLETE | 1.000000   | 0x0804878d | 17    | fcn.0804878d               |
+`--------------------------------------------------------------------------------------------------------------------------'
+```
+
+Look at that! crackme0x08 is completely identical to crackme0x07! With one exception however, crackme0x08 *adds* the
+symbol names back. Or looking at it another way: crackme0x07 is the stripped version of crackme0x08.
+
+That means we can solve it the exact same way we solved crackme0x07.
 
 ```bash
-$ export LOLAA=help
-$ ./cracke0x08
+$ LOL= ./crackme0x08
 IOLI Crackme Level 0x08
 Password: 12346
 Password OK!
+
+$ LOL= ./crackme0x08
+IOLI Crackme Level 0x08
+Password: 88
+Password OK!
 ```
 
-[dustri](https://dustri.org/b/defeating-ioli-with-rizin.html) provided a better way to check crackme0x08. 0x07 is the stripped version of 0x08.
+And our `exit` trampoline from the previous version still works as well.
 
 ```bash
-$ rz-diff -A -C ./crackme0x07 ./crackme0x08
-...
-              fcn.08048360  23 0x8048360 |   MATCH  (1.000000) | 0x8048360   23 sym._init
- sym.imp.__libc_start_main   6 0x8048388 |   MATCH  (1.000000) | 0x8048388    6 sym.imp.__libc_start_main
-             sym.imp.scanf   6 0x8048398 |   MATCH  (1.000000) | 0x8048398    6 sym.imp.scanf
-            sym.imp.strlen   6 0x80483a8 |   MATCH  (1.000000) | 0x80483a8    6 sym.imp.strlen
-            sym.imp.printf   6 0x80483b8 |   MATCH  (1.000000) | 0x80483b8    6 sym.imp.printf
-            sym.imp.sscanf   6 0x80483c8 |   MATCH  (1.000000) | 0x80483c8    6 sym.imp.sscanf
-           sym.imp.strncmp   6 0x80483d8 |   MATCH  (1.000000) | 0x80483d8    6 sym.imp.strncmp
-              sym.imp.exit   6 0x80483e8 |   MATCH  (1.000000) | 0x80483e8    6 sym.imp.exit
-                    entry0  33 0x8048400 |   MATCH  (1.000000) | 0x8048400   33 entry0
-              fcn.08048424  33 0x8048424 |   MATCH  (1.000000) | 0x8048424   33 fcn.08048424
-              fcn.08048450  47 0x8048450 |   MATCH  (1.000000) | 0x8048450   47 sym.__do_global_dtors_aux
-              fcn.08048480  50 0x8048480 |   MATCH  (1.000000) | 0x8048480   50 sym.frame_dummy
-              fcn.080484b4 112 0x80484b4 |   MATCH  (1.000000) | 0x80484b4  112 sym.dummy
-              fcn.08048524  30 0x8048524 |   MATCH  (1.000000) | 0x8048524   30 sym.che
-              fcn.08048542 119 0x8048542 |   MATCH  (1.000000) | 0x8048542  119 sym.parell
-              fcn.080485b9 118 0x80485b9 |   MATCH  (1.000000) | 0x80485b9  118 sym.check
-                      main  92 0x804867d |   MATCH  (1.000000) | 0x804867d   92 main
-              fcn.08048755   4 0x8048755 |   MATCH  (1.000000) | 0x8048755    4 sym.__i686.get_pc_thunk.bx
-              fcn.08048760  35 0x8048760 |   MATCH  (1.000000) | 0x8048760   35 sym.__do_global_ctors_aux
-              fcn.0804878d  17 0x804878d |     NEW  (0.000000)
-       sym.__libc_csu_init  99 0x80486e0 |     NEW  (0.000000)
-       sym.__libc_csu_fini   5 0x8048750 |     NEW  (0.000000)
-                 sym._fini  26 0x8048784 |     NEW  (0.000000)
+$ LD_PRELOAD=./libexit.so LOL= ./crackme0x08
+IOLI Crackme Level 0x08
+Password: 2
+Password Incorrect!
+wtf?
+
+$ LD_PRELOAD=./libexit.so LOL= ./crackme0x08
+IOLI Crackme Level 0x08
+Password: 88
+Password OK!
+Password Incorrect!
+wtf?
 ```
+Analyzing the binary, there is not much to discover that we didn't already know. With the exception that `print_and_exit`
+is actually called `che`. And the mysterious global variable referenced in `dummy` is called `LOL`.

--- a/src/crackmes/ioli/ioli_0x09.md
+++ b/src/crackmes/ioli/ioli_0x09.md
@@ -1,12 +1,183 @@
 IOLI 0x09
 =========
 
-Hints: crackme0x09 hides the format string (%d and %s), and nothing more than 0x08.
+And that brings us onto the last crackme.
+
+We can also use `rz-diff` to check for string differences.
+
+```diff
+$ rz-diff -t strings crackme0x08 crackme0x09
+--- crackme0x08
++++ ./crackme0x09
+@@ -1,4 +1,4 @@
+-IOLI Crackme Level 0x08
+
++IOLI Crackme Level 0x09
+
+ Password Incorrect!
+
+ Password OK!
+
+ Password: 
+```
+
+The only change is the version info (from 0x08 to 0x09). So let's check for functions.
+
+```diff
+$ rz-diff -t functions crackme0x08 ./crackme0x09
+.--------------------------------------------------------------------------------------------------------------------------.
+| name0                      | size0 | addr0      | type     | similarity | addr1      | size1 | name1                     |
+)--------------------------------------------------------------------------------------------------------------------------(
+| sym._init                  | 23    | 0x08048360 | PARTIAL  | 0.826087   | 0x08048388 | 23    | fcn.08048388              |
+| sym.imp.__libc_start_main  | 6     | 0x08048388 | COMPLETE | 1.000000   | 0x080483b0 | 6     | sym.imp.__libc_start_main |
+| sym.imp.scanf              | 6     | 0x08048398 | COMPLETE | 1.000000   | 0x080483c0 | 6     | sym.imp.scanf             |
+| sym.imp.strlen             | 6     | 0x080483a8 | COMPLETE | 1.000000   | 0x080483d0 | 6     | sym.imp.strlen            |
+| sym.imp.printf             | 6     | 0x080483b8 | COMPLETE | 1.000000   | 0x080483e0 | 6     | sym.imp.printf            |
+| sym.imp.sscanf             | 6     | 0x080483c8 | COMPLETE | 1.000000   | 0x080483f0 | 6     | sym.imp.sscanf            |
+| sym.imp.strncmp            | 6     | 0x080483d8 | COMPLETE | 1.000000   | 0x08048400 | 6     | sym.imp.strncmp           |
+| sym.imp.exit               | 6     | 0x080483e8 | COMPLETE | 1.000000   | 0x08048410 | 6     | sym.imp.exit              |
+| fcn.08048424               | 33    | 0x08048424 | PARTIAL  | 0.939394   | 0x08048444 | 33    | fcn.08048444              |
+| sym.__do_global_dtors_aux  | 47    | 0x08048450 | COMPLETE | 1.000000   | 0x08048470 | 47    | fcn.08048470              |
+| sym.frame_dummy            | 50    | 0x08048480 | PARTIAL  | 0.940000   | 0x080484a0 | 50    | fcn.080484a0              |
+| sym.dummy                  | 112   | 0x080484b4 | PARTIAL  | 0.554745   | 0x080484d4 | 137   | fcn.080484d4              |
+| sym.che                    | 30    | 0x08048524 | UNLIKE   | 0.4773     | 0x0804855d | 44    | fcn.0804855d              |
+| sym.parell                 | 119   | 0x08048542 | PARTIAL  | 0.581560   | 0x08048589 | 141   | fcn.08048589              |
+| sym.check                  | 118   | 0x080485b9 | PARTIAL  | 0.689394   | 0x08048616 | 132   | fcn.08048616              |
+| sym.__i686.get_pc_thunk.bx | 4     | 0x08048755 | COMPLETE | 1.000000   | 0x08048766 | 4     | fcn.08048766              |
+| sym.__do_global_ctors_aux  | 35    | 0x08048760 | PARTIAL  | 0.942857   | 0x080487f0 | 35    | fcn.080487f0              |
+| fcn.0804878d               | 17    | 0x0804878d | PARTIAL  | 0.823529   | 0x0804881d | 17    | fcn.0804881d              |
+`--------------------------------------------------------------------------------------------------------------------------'
+```
+
+We can see that a few functions have been changed. So let's check it out! We can also see that this
+version strips the symbol names again, but that should be no problem. We can easily identify them using the functions diff.
 
 ```bash
-$ export LOLA=help
-$ ./crackme0x09
+$ rizin ./crackme0x09
+[0x08048420]> aa
+[0x08048420]> afr @ main # recursively analyze functions, starting from main
+[0x08048420]> afn check @ fcn.08048616
+[0x08048420]> afn parell @ fcn.08048589
+[0x08048420]> afn che @ fcn.0804855d
+[0x08048420]> afn dummy @ fcn.080484d4
+```
+```c
+[0x08048420]> pdg @ main
+
+// WARNING: Variable defined which should be unmapped: var_8h
+// WARNING: [rz-ghidra] Detected overlap for variable var_15h
+
+undefined4 main(undefined4 placeholder_0, undefined4 placeholder_1, char **envp)
+{
+    int32_t unaff_EBX;
+    int32_t var_88h;
+    int32_t var_7ch;
+    int32_t var_8h;
+    
+    fcn.08048766();
+    sym.imp.printf(unaff_EBX + 0x16c);
+    sym.imp.printf(unaff_EBX + 0x185);
+    sym.imp.scanf(unaff_EBX + 400, &var_7ch);
+    check((int32_t)&var_7ch, (int32_t)envp);
+    return 0;
+}
+```
+
+Looking at `main` we can see some changes: a new function `fcn.08048766` is introduced, and all string addresses have
+been replaced by offsets to some base address `unaff_EBX`.
+
+Looking at the functions diff we can see that `fcn.08048766` is named `__i686.get_pc_thunk.bx`. This function is used
+in position-independent code to get the addresses of global constants (like string constants). Let's see if we can find
+out to which strings these offsets resolve to, but let's first give this new function a name.
+
+
+```bash
+[0x08048420]> afn sym.__i686.get_pc_thunk.bx @ fcn.08048766
+```
+
+To compute the addresses we can use ESIL. But we need to initialize it first.
+
+```bash
+[0x08048420]> s main
+[0x080486ee]> aei
+[0x080486ee]> aeip
+[0x080486ee]> aeim
+```
+
+Now we can step through the function, and all pointer arithmetic will be simulated! Open the interactive view
+with `v`, and then we can step through using the `s` key to step in and `S` to step over (this also works
+when using the debugger).
+
+```bash
+[0x080486ee]> v
+# opens visual mode
+# step through by pressing Shift+S until we hit the instruction
+# call instruction to printf()
+```
+
+Having landed at the call to `printf` we can now look at what the address in `eax` points to. Exit
+visual mode by pressing `q`.
+
+
+```bash
+[0x080486ee]> ar eax
+eax = 0x08048869
+[0x080486ee]> ps @ 0x08048869
+IOLI Crackme Level 0x09
+```
+
+We can add this as a comment if we want. This way we don't have to keep doing this ESIL simulation if we forget
+what particular string was printed here.
+
+```bash
+[0x080486ef]> CC "IOLI Crackme Level 0x09" @ eip
+[0x080486ef]> pd 1 @ eip
+```
+```asm
+│           ;-- eip:
+│           0x08048722      call  sym.imp.printf                       ; sym.imp.printf ; IOLI Crackme Level 0x09 ; int printf(const char *format)
+```
+
+Perfect! Onto the next string. We can skip the call to `printf` with the `aess` command, and then perform two steps using
+`aes 2`.
+
+```bash
+[0x080486ee]> aess
+[0x080486ee]> aes 2
+[0x080486ee]> ar eax
+eax = 0x08048882
+[0x080486ee]> ps @ 0x08048882
+Password:
+```
+
+We can continue this until we have identified all strings. Or until our curiosity is sated.
+
+Either way, nothing of note has been added or changed in this version, which means that
+the password constraints are still the same.
+
+```bash
+$ LOL= ./crackme0x09
 IOLI Crackme Level 0x09
 Password: 12346
 Password OK!
+
+$ LOL= ./crackme0x09
+IOLI Crackme Level 0x09
+Password: 888
+Password OK!
+
+$ LD_PRELOAD=./libexit.so LOL= ./crackme0x09
+IOLI Crackme Level 0x09
+Password: 2
+Password Incorrect!
+wtf?
+
+$ LD_PRELOAD=./libexit.so LOL= ./crackme0x09
+IOLI Crackme Level 0x09
+Password: 888
+Password OK!
+Password Incorrect!
+wtf?
 ```
+
+And that concludes the IOLI crackmes!


### PR DESCRIPTION
# do not squash

Hello!

I was recently working through the IOLI Crackmes section of the book, and noticed that
some commands were (presumibly) out of date, or that there functionality was moved to
a different command.

This updates most of them, and provides their current (I'm using version 0.7.2) outputs. I also
replaced the usage of `jsdec` with `rz-ghidra` (which provides much nicer output in my
opinion), expanded some sections to provide some more detailed analysis,
and fixed grammar in some places.

It should be noted that I'm fairly new to Rizin, and reversing in general, so my
changes should probably be looked at with some scrutiny :)

Thanks!

(This should also fix issue #95)