### PR TITLE
Update "/ lib" invocation on /bin/ls

### DIFF
--- a/src/search_bytes/basic_searches.md
+++ b/src/search_bytes/basic_searches.md
@@ -4,17 +4,23 @@ A basic search for a plain text string in a file would be something like:
 
 ```shell
 $ rizin -q -c "/ lib" /bin/ls
-Searching 3 bytes from 0x00400000 to 0x0041ae08: 6c 69 62 
-hits: 9
-0x00400239 hit0_0 "lib64/ld-linux-x86-64.so.2"
-0x00400f19 hit0_1 "libselinux.so.1"
-0x00400fae hit0_2 "librt.so.1"
-0x00400fc7 hit0_3 "libacl.so.1"
-0x00401004 hit0_4 "libc.so.6"
-0x004013ce hit0_5 "libc_start_main"
-0x00416542 hit0_6 "libs/"
-0x00417160 hit0_7 "lib/xstrtol.c"
-0x00417578 hit0_8 "lib"
+Searching 3 bytes in [0x23548,0x23f18)
+hits: 0
+Searching 3 bytes in [0x0,0x3458)
+hits: 4
+Searching 3 bytes in [0x4000,0x17091)
+hits: 0
+Searching 3 bytes in [0x18000,0x1f458)
+hits: 1
+Searching 3 bytes in [0x22278,0x23540)
+hits: 0
+Searching 3 bytes in [0x20fd0,0x22278)
+hits: 0
+0x00000319 hit0_0 ".............../lib64/ld-linux-x86-"
+0x00000f9a hit0_1 "_cxa_finalize.__libc_start_main.__c"
+0x000014a2 hit0_2 "con.lgetfilecon.libselinux.so.1.lib"
+0x000014b2 hit0_3 "libselinux.so.1.libc.so.6.LIBSELINU"
+0x00019c6f hit0_4 "-.full-iso.lc./.libs/.lt-./usr/shar"
 ```
 
 As can be seen from the output above, Rizin generates a "hit" flag for every entry found. You can then use the `ps`


### PR DESCRIPTION
The pr updates the "/ lib" invocation with the update partly due to rizinorg/rizin#4880.

I don't think the search results can be clarified further without color, and without:

1. A way to change the character used for nonprintable chars.
2. The use of `^^^` or `vvv` etc. to show where the searched string is.

The above are currently not a priority.