### PR TITLE
Update `rizin -h` in commandline_options.md

### DIFF
--- a/src/first_steps/commandline_options.md
+++ b/src/first_steps/commandline_options.md
@@ -4,7 +4,7 @@ The `rizin` command line tool supports various options from the shell command li
 
 Here is the usage help message:
 
-```
+```bash
 $ rizin -h
 Usage: rizin [-ACdfLMnNqStuvwzX] [-P patch] [-p prj] [-a arch] [-b bits] [-i file]
              [-s addr] [-B baddr] [-m maddr] [-c cmd] [-e k=v] file|pid|-|--|=


### PR DESCRIPTION
This pr updates `rizin -h` in [src/first_steps/commandline_options.md](https://github.com/rizinorg/book/blob/fe59672b86db15e3ef101e552e7bf424fa113450/src/first_steps/commandline_options.md) with the latest `rizin -h` output (i.e. up to rizinorg/rizin#5336). ~~The `bash` tag was removed because the syntax coloring was weird.~~