### PR TITLE
Fix `rizin -h` coloring in commandline_options.md

### DIFF
--- a/src/first_steps/commandline_options.md
+++ b/src/first_steps/commandline_options.md
@@ -9,7 +9,7 @@ $ rizin -h
 Usage: rizin [-ACdfLMnNqStuvwzX] [-P patch] [-p prj] [-a arch] [-b bits] [-i file]
              [-s addr] [-B baddr] [-m maddr] [-c cmd] [-e k=v] file|pid|-|--|=
  --         Run rizin without opening any file
- =          Same as 'rizin malloc://512
+ =          Same as 'rizin malloc://512'
  -          Read file from stdin
  -=         Perform R=! command to run all commands remotely
  -0         Print \x00 after init and every command
@@ -21,7 +21,7 @@ Usage: rizin [-ACdfLMnNqStuvwzX] [-P patch] [-p prj] [-a arch] [-b bits] [-i fil
  -B baddr   Set base address for PIE binaries
  -c 'cmd..' Execute rizin command
  -C         File is host:port (alias for -cR+http://%%s/cmd/)
- -d         Debug the executable 'file' or running process 'pid
+ -d         Debug the executable 'file' or running process 'pid'
  -D backend Enable debug mode (e cfg.debug=true)
  -e k=v     Evaluate config var
  -f         Block size = file size


### PR DESCRIPTION
This pr updates `rizin -h` in [src/first_steps/commandline_options.md](https://github.com/rizinorg/book/blob/5674518d91df63e0f95b02905bde6d31864c048c/src/first_steps/commandline_options.md) to rizinorg/rizin#5343 to fix its syntax coloring.