### PR TITLE
Macro defs use name placeholders now

### DIFF
--- a/src/scripting/macros.md
+++ b/src/scripting/macros.md
@@ -64,7 +64,7 @@ simple scripting situations. To create a macro that takes arguments you simply a
 
 ```
 [0x00404800]> s entry0
-[0x004047d0]> (foo x y; pd $0; sd +$1)
+[0x004047d0]> (foo x y; pd ${x}; sd +${y})
 [0x004047d0]> .(foo 5 6)
 ;-- entry0:
 0x004047d0      xor ebp, ebp
@@ -74,8 +74,6 @@ simple scripting situations. To create a macro that takes arguments you simply a
 0x004047d9      and rsp, 0xfffffffffffffff0
 [0x004047d6]>
 ```
-
-As you can see, the arguments are named by index, starting from 0: $0, $1, ...
 
 To run a macro multiple times with different arguments, a convenient way is to use `..(`:
 


### PR DESCRIPTION
This pr updates [src/scripting/macros.md](https://github.com/rizinorg/book/blob/560a76ccc41348746d821b228dbef5e6a826a1f8/src/scripting/macros.md) in that macro definitions use name placeholders now.