### PR TITLE
Update `rz-ax -h` to rizinorg/rizin#5413

### DIFF
--- a/src/tools/rz-ax/intro.md
+++ b/src/tools/rz-ax/intro.md
@@ -30,54 +30,54 @@ This is the help message of rz-ax -h, which will show you a bunch more syntaxes:
 $ rz-ax -h
 Usage: rz-ax [options] [expr ...]
 If expr is not provided, reads from stdin
-  int     ->  hex              ;  rz-ax 10
-  hex     ->  int              ;  rz-ax 0xa
-  -int    ->  hex              ;  rz-ax -77
-  -hex    ->  int              ;  rz-ax 0xffffffb3
-  int     ->  bin              ;  rz-ax b30
-  int     ->  ternary          ;  rz-ax t42
-  bin     ->  int              ;  rz-ax 1010d
-  ternary ->  int              ;  rz-ax 1010dt
-  float   ->  hex              ;  rz-ax 3.33f
-  hex     ->  float            ;  rz-ax Fx40551ed8
-  oct     ->  hex              ;  rz-ax 35o
-  hex     ->  oct              ;  rz-ax Ox12 (O is a letter)
-  bin     ->  hex              ;  rz-ax 1100011b
-  hex     ->  bin              ;  rz-ax Bx63
-  ternary ->  hex              ;  rz-ax 212t
-  hex     ->  ternary          ;  rz-ax Tx23
-  raw     ->  hex              ;  rz-ax -S < /binfile
-  hex     ->  raw              ;  rz-ax -s 414141
-  =base                        ;  rz-ax =10 0x46 -> output in base 10
-  -l                           ;  append newline to output (for -E/-D/-r/..
-  -a      show ascii table     ;  rz-ax -a
-  -b      bin -> str           ;  rz-ax -b 01000101 01110110
-  -B      str -> bin           ;  rz-ax -B hello
-  -d      force integer        ;  rz-ax -d 3 -> 3 instead of 0x3
-  -e      swap endianness      ;  rz-ax -e 0x33
-  -D      base64 decode        ;
-  -E      base64 encode        ;
-  -f      floating point       ;  rz-ax -f 6.3+2.1
-  -F      stdin slurp code hex ;  rz-ax -F < shellcode.[c/py/js]
-  -h      show this help       ;  rz-ax -h
-  -i      dump as C byte array ;  rz-ax -i < bytes
-  -I      IP address <-> LONG  ;  rz-ax -I 3530468537
-  -k      keep base            ;  rz-ax -k 33+3 -> 36
-  -L      bin -> hex(bignum)   ;  rz-ax -L 111111111 # 0x1ff
-  -n      int value -> hexpairs;  rz-ax -n 0x1234 # 34120000
-  -o      octalstr -> raw      ;  rz-ax -o \162 \172 # rz
-  -N      binary number        ;  rz-ax -N 0x1234 # \x34\x12\x00\x00
-  -r      rz style output      ;  rz-ax -r 0x1234
-  -s      hexstr -> raw        ;  rz-ax -s 43 4a 50
-  -S      raw -> hexstr        ;  rz-ax -S < /bin/ls > ls.hex
-  -t      Unix tstamp -> str   ;  rz-ax -t 1234567890
-  -m      MS-DOS tstamp -> str ;  rz-ax -m 1234567890
-  -W      Win32 tstamp -> str  ;  rz-ax -W 1234567890
-  -x      hash string          ;  rz-ax -x linux osx
-  -u      units                ;  rz-ax -u 389289238 # 317.0M
-  -w      signed word          ;  rz-ax -w 16 0xffff
-  -v      version              ;  rz-ax -v
-  -p      position of set bits ;  rz-ax -p 0xb3
+ int     ->  hex               ;  rz-ax 10
+ hex     ->  int               ;  rz-ax 0xa
+ -int    ->  hex               ;  rz-ax -77
+ -hex    ->  int               ;  rz-ax 0xffffffb3
+ int     ->  bin               ;  rz-ax b30
+ int     ->  ternary           ;  rz-ax t42
+ bin     ->  int               ;  rz-ax 1010d
+ ternary ->  int               ;  rz-ax 1010dt
+ float   ->  hex               ;  rz-ax 3.33f
+ hex     ->  float             ;  rz-ax Fx40551ed8
+ oct     ->  hex               ;  rz-ax 35o
+ hex     ->  oct               ;  rz-ax Ox12 (O is a letter)
+ bin     ->  hex               ;  rz-ax 1100011b
+ hex     ->  bin               ;  rz-ax Bx63
+ ternary ->  hex               ;  rz-ax 212t
+ hex     ->  ternary           ;  rz-ax Tx23
+ raw     ->  hex               ;  rz-ax -S < /binfile
+ hex     ->  raw               ;  rz-ax -s 414141
+ =base                         ;  rz-ax =10 0x46 -> output in base 10
+ -l                            ;  append newline to output (for -E/-D/-r/..
+ -a      show ascii table      ;  rz-ax -a
+ -b      bin -> str            ;  rz-ax -b 01000101 01110110
+ -B      str -> bin            ;  rz-ax -B hello
+ -d      force integer         ;  rz-ax -d 3 -> 3 instead of 0x3
+ -e      swap endianness       ;  rz-ax -e 0x33
+ -D      base64 decode
+ -E      base64 encode
+ -f      floating point        ;  rz-ax -f 6.3+2.1
+ -F      stdin slurp code hex  ;  rz-ax -F < shellcode.[c/py/js]
+ -h      show this help        ;  rz-ax -h
+ -i      dump as C byte array  ;  rz-ax -i < bytes
+ -I      IP address <-> LONG   ;  rz-ax -I 3530468537
+ -k      keep base             ;  rz-ax -k 33+3 -> 36
+ -L      bin -> hex(bignum)    ;  rz-ax -L 111111111 # 0x1ff
+ -n      int value -> hexpairs ;  rz-ax -n 0x1234 # 34120000
+ -o      octalstr -> raw       ;  rz-ax -o \162 \172 # rz
+ -N      binary number         ;  rz-ax -N 0x1234 # \x34\x12\x00\x00
+ -r      rz style output       ;  rz-ax -r 0x1234
+ -s      hexstr -> raw         ;  rz-ax -s 43 4a 50
+ -S      raw -> hexstr         ;  rz-ax -S < /bin/ls > ls.hex
+ -t      Unix tstamp -> str    ;  rz-ax -t 1234567890
+ -m      MS-DOS tstamp -> str  ;  rz-ax -m 1234567890
+ -W      Win32 tstamp -> str   ;  rz-ax -W 1234567890
+ -x      hash string           ;  rz-ax -x linux osx
+ -u      units                 ;  rz-ax -u 389289238 # 317.0M
+ -w      signed word           ;  rz-ax -w 16 0xffff
+ -v      version               ;  rz-ax -v
+ -p      position of set bits  ;  rz-ax -p 0xb3
 ```
 
 Some examples:


### PR DESCRIPTION
This pr just updates `rz-ax -h` in [src/tools/rz-ax/intro.md](https://github.com/rizinorg/book/blob/dff38bf0650a99135a30b1e10a5e40674c5ecafe/src/tools/rz-ax/intro.md) to rizinorg/rizin#5413. Mostly only spacing has been changed.