### PR TITLE
Add documentation for ppd/ De Bruijn offset command

### DIFF
--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -544,7 +544,8 @@ AABAACAADAAEAAFAAGAAHAAIAAJAAKAALAAMAANAAOAAPAAQAARAASAATAAUAAVAAWAAXAAYAAZAAaAA
 
 **Locate an observed value**
 
-Use `ppd/<value>` to look up where a value appears in the default pattern. This is the fastest way to translate a register/memory capture back into an offset.
+Use `ppd/ <value>` to look up where a value appears in the De Bruijn pattern. This is the fastest way to translate a register/memory capture back into an offset.
+The value is a sequence of ASCII bytes. In the example below it searches for "AWAA".
 
 ```
 [0x00000000]> e cfg.bigendian=false

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -553,7 +553,7 @@ The value is a sequence of ASCII bytes. In the example below it searches for "AW
 64
 ```
 
-The command respects `cfg.bigendian`, so flip it if your target is big-endian:
+The command respects `cfg.bigendian`, so flip it if your target is big-endian. The value is interpreted as a 64-bit integer (up to 8 bytes). Any leading zero bytes are dropped, so most inputs behave like 4-byte substrings, but every supplied byte participates in the endian swap:
 
 ```
 [0x00000000]> e cfg.bigendian=true

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -571,5 +571,5 @@ If you prefer to inject the pattern directly, `wD <len>` writes the same data at
 64
 ```
 
-(See [Writing Data](write.md#writing-data) for more on `wD`.)
+See [Writing Data](write.md#writing-data) for more on `wD`.
 

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -553,7 +553,7 @@ The value is a sequence of ASCII bytes. In the example below it searches for "AW
 64
 ```
 
-The command respects `cfg.bigendian`, so flip it if your target is big-endian. The value is interpreted as a 64-bit integer (up to 8 bytes). Any leading zero bytes are dropped, so most inputs behave like 4-byte substrings, but every supplied byte participates in the endian swap:
+The command respects `cfg.bigendian`, so flip it if your target is big-endian. The value is converted to an 8-byte representation according to the endianness setting, then any leading zero bytes are skipped before searching the pattern. For example, `0x41574141` is written as 8 bytes, but only the non-zero portion is searched:
 
 ```
 [0x00000000]> e cfg.bigendian=true
@@ -563,11 +563,11 @@ The command respects `cfg.bigendian`, so flip it if your target is big-endian. T
 
 **Writing the pattern**
 
-If you prefer to inject the pattern directly, `wD <len>` writes the same data at the current seek, and `wD/ <value>` mirrors the lookup behavior:
+You can also write the De Bruijn pattern directly to memory. The `wD <len>` command writes a pattern of the specified length at the current offset, and `wD/ <value>` finds the offset of a value in the pattern (identical to `ppd/ <value>`):
 
 ```
-[0x00000000]> wD 100        # Write 100 bytes of the pattern
-[0x00000000]> wD/ 0x41574141
+[0x00000000]> wD 100        # Write 100 bytes of the pattern to memory
+[0x00000000]> wD/ 0x41574141 # Find offset (doesn't write, only searches)
 64
 ```
 

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -528,7 +528,7 @@ The `pp` command group generates deterministic patterns that are handy for fuzzi
 Usage: pp[?]   # Print patterns
 | pp[ad] [len]   # Print different patterns
 | ppd <len>      # Print De Bruijn pattern of length <len>
-| ppd/<value>    # Show the offset of <value> in the default De Bruijn pattern (honors cfg.bigendian)
+| ppd/ <value>    # Show the offset of <value> in the default De Bruijn pattern (honors cfg.bigendian)
 ```
 
 #### De Bruijn patterns

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -563,7 +563,7 @@ The command respects `cfg.bigendian`, so flip it if your target is big-endian:
 
 **Writing the pattern**
 
-If you prefer to inject the pattern directly, `wD <len>` writes the same data at the current seek, and `wD/<value>` mirrors the lookup behavior:
+If you prefer to inject the pattern directly, `wD <len>` writes the same data at the current seek, and `wD/ <value>` mirrors the lookup behavior:
 
 ```
 [0x00000000]> wD 100        # Write 100 bytes of the pattern

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -535,7 +535,7 @@ Usage: pp[?]   # Print patterns
 
 De Bruijn sequences are cyclic patterns in which every substring of the chosen width appears exactly once. They’re perfect for recovering overwrite offsets after a crash.
 
-**Generate a pattern**
+**Generate a De Bruijn pattern**
 
 ```
 [0x00000000]> ppd 100

--- a/src/basic_commands/print_modes.md
+++ b/src/basic_commands/print_modes.md
@@ -518,3 +518,57 @@ the position (like coordinates) and the height and width of the gadget you would
 the configuration variable `scr.gadgets` to be turned on.
 
 See `pg?` for more information.
+
+### Print Patterns
+
+The `pp` command group generates deterministic patterns that are handy for fuzzing, debugging, and exploit development.
+
+```
+[0x00000000]> pp?
+Usage: pp[?]   # Print patterns
+| pp[ad] [len]   # Print different patterns
+| ppd <len>      # Print De Bruijn pattern of length <len>
+| ppd/<value>    # Show the offset of <value> in the default De Bruijn pattern (honors cfg.bigendian)
+```
+
+#### De Bruijn patterns
+
+De Bruijn sequences are cyclic patterns in which every substring of the chosen width appears exactly once. They’re perfect for recovering overwrite offsets after a crash.
+
+**Generate a pattern**
+
+```
+[0x00000000]> ppd 100
+AABAACAADAAEAAFAAGAAHAAIAAJAAKAALAAMAANAAOAAPAAQAARAASAATAAUAAVAAWAAXAAYAAZAAaAAbAAcAAdAAeAAfAAgAAh
+```
+
+**Locate an observed value**
+
+Use `ppd/<value>` to look up where a value appears in the default pattern. This is the fastest way to translate a register/memory capture back into an offset.
+
+```
+[0x00000000]> e cfg.bigendian=false
+[0x00000000]> ppd/ 0x41574141
+64
+```
+
+The command respects `cfg.bigendian`, so flip it if your target is big-endian:
+
+```
+[0x00000000]> e cfg.bigendian=true
+[0x00000000]> ppd/ 0x41574141
+65
+```
+
+**Writing the pattern**
+
+If you prefer to inject the pattern directly, `wD <len>` writes the same data at the current seek, and `wD/<value>` mirrors the lookup behavior:
+
+```
+[0x00000000]> wD 100        # Write 100 bytes of the pattern
+[0x00000000]> wD/ 0x41574141
+64
+```
+
+(See [Writing Data](write.md#writing-data) for more on `wD`.)
+


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://github.com/rizinorg/book/blob/master/README.md) to this repository.
- [x] I've verified the documentation builds correctly locally (if applicable).
- [x] I've checked that my changes follow the existing documentation style and formatting.

**Detailed description**

This PR adds documentation for the new `ppd/<value>` command introduced in rizinorg/rizin#5532. The command allows users to find the offset where a specific value appears in the De Bruijn pattern, which is useful for exploit development and buffer overflow analysis.

The documentation is added to `src/basic_commands/print_modes.md` in the pattern section and includes:

- Overview of the `pp` command group
- Explanation of De Bruijn patterns and their use cases
- Examples of generating patterns with `ppd <len>`
- Examples of finding offsets with `ppd/<value>`
- Demonstration of `cfg.bigendian` configuration impact
- Cross-reference to related `wD` write commands

**Related issue/PR**

- Related to rizinorg/rizin#5532

**Screenshots/Examples**

The documentation includes practical examples showing:
- Pattern generation
- Offset lookup in little-endian mode (result: 64)
- Offset lookup in big-endian mode (result: 65)
- Integration with write commands (`wD`)