### PR TITLE
match the textual description to graphic

### DIFF
--- a/src/visual_mode/visual_assembler.md
+++ b/src/visual_mode/visual_assembler.md
@@ -1,7 +1,7 @@
 # Visual Assembler
 
 You can use Visual Mode to assemble code (patch) using `A`.
-For example, let's `xor` the EAX register instead of EBP register, here.
+For example, let's change the condition and target for the first conditional jump instruction in the example below.
 To assemble, seek to the location you want to patch and press `A`.
 
 ![Before](assembler_before.png)


### PR DESCRIPTION
The textual description for the example in `visual_assembler.md` did not match the graphic, hence I fixed it.
However, I did not verify whether the commands described in the example are valid and working.

**Your checklist for this pull request**
- [ ] I've used AI tools to generate these changes, fully or partially.
- [ ] I've manually tested all commands and examples in these changes.
